### PR TITLE
Full DriftWatch improvement: caching, tickets, alerts, dark mode, tes…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "pandas<3" numpy requests scikit-learn joblib pytest "evidently==0.6.7"
+          pip install -r scripts/requirements.txt
 
       - name: Python tests
         run: pytest tests/ -v
+        working-directory: ${{ github.workspace }}

--- a/.github/workflows/monitor_run.yml
+++ b/.github/workflows/monitor_run.yml
@@ -35,17 +35,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       DRIFTWATCH_STORAGE_BUCKET: ${{ secrets.DRIFTWATCH_STORAGE_BUCKET || 'driftwatch-artifacts' }}
-      DRIFTWATCH_UPLOAD_HTML: "true"
+      DRIFTWATCH_UPLOAD_HTML: "false"
       NORDEA_ENV: ${{ secrets.NORDEA_ENV || 'sandbox' }}
       NORDEA_SIGNATURE_BYPASS: ${{ secrets.NORDEA_SIGNATURE_BYPASS || 'true' }}
       NORDEA_CLIENT_ID: ${{ secrets.NORDEA_CLIENT_ID }}
       NORDEA_CLIENT_SECRET: ${{ secrets.NORDEA_CLIENT_SECRET }}
       NORDEA_TOKEN_URL: ${{ secrets.NORDEA_TOKEN_URL }}
       NORDEA_API_BASE_URL: ${{ secrets.NORDEA_API_BASE_URL }}
+      APP_ORIGIN: ${{ secrets.APP_ORIGIN }}
+      GITHUB_REPO: ${{ github.repository }}
     steps:
       - uses: actions/checkout@v4
 
@@ -54,9 +57,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install "pandas<3" numpy requests "evidently==0.6.7" scikit-learn joblib
+        run: pip install -r scripts/requirements.txt
 
       - name: Run drift pipeline
         run: |
@@ -67,4 +68,18 @@ jobs:
           python scripts/monitor_run.py \
             --domain "${{ github.event.inputs.domain || 'nordea' }}" \
             --baseline-version "${{ github.event.inputs.baseline_version || 'v1' }}" \
-            --batch-id "${BATCH_ID}"
+            --batch-id "${BATCH_ID}" \
+            --triggered-by "${{ github.event_name == 'schedule' && 'cron' || 'admin' }}"
+
+      - name: Notify on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[DriftWatch] monitor_run failed ${new Date().toISOString().slice(0,10)}`,
+              body: `## Daily Drift Monitor Failed\n\n**Run ID**: ${context.runId}\n**Triggered by**: ${context.eventName}\n\n[View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})\n\nCheck the workflow logs for details.`,
+              labels: ['monitor-failure']
+            })

--- a/README.md
+++ b/README.md
@@ -11,6 +11,42 @@ It demonstrates production-shaped MLOps behavior:
 - incident ticketing
 - auditable run history
 
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    DRIFTWATCH ARCHITECTURE                       │
+│                                                                  │
+│  INGEST               COMPUTE               STORE               │
+│  ──────               ───────               ─────               │
+│  nordea_sync      →   monitor_run.py    →   monitor_runs        │
+│  generate_batch   →   data_quality     →   feature_drift_metrics│
+│                   →   performance      →   model_performance     │
+│                   →   retrain_trigger  →   retraining_events    │
+│                   →   alert_dispatcher →   alert_logs           │
+│                                                                  │
+│  INFRA                SERVE                                      │
+│  ─────                ─────                                      │
+│  GitHub Actions   →   Supabase REST    →   Next.js (Vercel)     │
+│  (compute)            (Postgres + S3)      (dashboard + admin)  │
+│                                                                  │
+│  ALERT ROUTING                                                   │
+│  ─────────────                                                   │
+│  drift_status=red  →  GitHub Issue (auto-created via GITHUB_TOKEN)│
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Storage lifecycle
+
+| Artifact | Policy |
+|----------|--------|
+| HTML reports | Off by default (`DRIFTWATCH_UPLOAD_HTML=false`). Deleted after 30 days by sweeper. |
+| Model artifacts (.joblib) | Retained per baseline version |
+| Baseline CSVs | Retained per baseline version |
+| Feature batch CSVs | Overwritten per batch_id |
+
+Storage quota is monitored in `keepalive.py` and warns at 400MB (Supabase free: 1GB).
+
 ## Why this project exists
 
 A common portfolio failure is building a strong model notebook but no production monitoring system.

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,8 +1,9 @@
 import { redirect } from "next/navigation";
 import AdminActions from "@/components/admin-actions";
 import { requireAdminSession } from "@/lib/admin-auth";
-import { getRuns } from "@/lib/supabase";
+import { getPendingRetrainingEvents, getRuns, getSystemHealthStats } from "@/lib/supabase";
 import { toUiRuns } from "@/lib/ui-mappers";
+import { formatScore } from "@/lib/format";
 
 export default async function AdminPage() {
   const isAdmin = requireAdminSession();
@@ -10,7 +11,11 @@ export default async function AdminPage() {
     redirect("/admin/login");
   }
 
-  const recentRuns = toUiRuns(await getRuns(10).catch(() => []));
+  const [recentRuns, pendingEvents, healthStats] = await Promise.all([
+    getRuns(10).catch(() => []).then(toUiRuns),
+    getPendingRetrainingEvents().catch(() => []),
+    getSystemHealthStats().catch(() => null),
+  ]);
 
   return (
     <div className="min-h-screen bg-white">
@@ -20,6 +25,74 @@ export default async function AdminPage() {
           These actions dispatch GitHub workflows only. Drift compute and privileged writes happen in GitHub
           Actions.
         </p>
+
+        {pendingEvents.length > 0 ? (
+          <section className="rounded-lg border-2 border-[#F59E0B] bg-white p-6">
+            <h2 className="mb-3 text-lg font-bold text-nordea-navy">
+              Pending Retraining Events ({pendingEvents.length})
+            </h2>
+            <div className="space-y-3">
+              {pendingEvents.map((event) => (
+                <div key={event.id} className="flex items-start justify-between rounded-lg bg-[#FEF3C7] p-3">
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-nordea-navy">
+                      Policy: <span className="font-mono">{event.policy_name}</span>
+                    </p>
+                    <p className="text-xs text-[#6B7280]">
+                      {event.consecutive_red_count} consecutive red runs — PSI:{" "}
+                      {formatScore(event.prediction_drift_score, 4)}
+                    </p>
+                    <p className="text-xs text-[#6B7280]">
+                      Baseline: {event.baseline_version ?? "—"} · Triggered: {new Date(event.triggered_at).toLocaleString()}
+                    </p>
+                  </div>
+                  <span className="rounded-full bg-[#F59E0B] px-2 py-1 text-xs font-medium text-white">
+                    PENDING
+                  </span>
+                </div>
+              ))}
+            </div>
+            <p className="mt-3 text-xs text-[#6B7280]">
+              Approve: use Baseline Refresh below to retrain the champion model.
+            </p>
+          </section>
+        ) : null}
+
+        {healthStats ? (
+          <section className="rounded-lg border border-[#E5E5E5] bg-white p-6">
+            <h2 className="mb-4 text-lg font-bold text-nordea-navy">System Health</h2>
+            <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+              <div className="rounded-lg border border-[#E5E5E5] bg-[#F9F9F9] p-4">
+                <p className="text-xs uppercase text-[#6B7280]">Avg Duration</p>
+                <p className="text-xl font-bold text-nordea-navy">
+                  {healthStats.avgDurationSeconds.toFixed(0)}s
+                </p>
+              </div>
+              <div className="rounded-lg border border-[#E5E5E5] bg-[#F9F9F9] p-4">
+                <p className="text-xs uppercase text-[#6B7280]">p95 Duration</p>
+                <p className="text-xl font-bold text-nordea-navy">
+                  {healthStats.p95DurationSeconds.toFixed(0)}s
+                </p>
+              </div>
+              <div className="rounded-lg border border-[#E5E5E5] bg-[#F9F9F9] p-4">
+                <p className="text-xs uppercase text-[#6B7280]">Avg Batch Size</p>
+                <p className="text-xl font-bold text-nordea-navy">
+                  {healthStats.avgBatchSize.toFixed(0)}
+                </p>
+              </div>
+              <div className="rounded-lg border border-[#E5E5E5] bg-[#F9F9F9] p-4">
+                <p className="text-xs uppercase text-[#6B7280]">Total Rows</p>
+                <p className="text-xl font-bold text-nordea-navy">
+                  {healthStats.totalRowsProcessed.toLocaleString()}
+                </p>
+              </div>
+            </div>
+            <p className="mt-2 text-xs text-[#6B7280]">
+              Based on last {healthStats.sampleCount} monitor runs.
+            </p>
+          </section>
+        ) : null}
+
         <AdminActions initialRuns={recentRuns} />
       </div>
     </div>

--- a/app/api/admin/baseline-refresh/route.ts
+++ b/app/api/admin/baseline-refresh/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { dispatchAdminWorkflow } from "@/lib/admin-dispatch";
+import { validateBaselineRefreshInputs } from "@/lib/admin-validation";
 
 type BaselineBody = {
   domain?: string;
@@ -12,6 +13,11 @@ type BaselineBody = {
 
 export async function POST(request: NextRequest) {
   const body = ((await request.json().catch(() => ({}))) ?? {}) as BaselineBody;
+
+  const errors = validateBaselineRefreshInputs(body as Record<string, unknown>);
+  if (errors.length > 0) {
+    return NextResponse.json({ error: "Validation failed", details: errors }, { status: 400 });
+  }
 
   return dispatchAdminWorkflow(request, "baseline_refresh.yml", {
     domain: body.domain ?? "nordea",

--- a/app/api/admin/generate-batch/route.ts
+++ b/app/api/admin/generate-batch/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { dispatchAdminWorkflow } from "@/lib/admin-dispatch";
+import { validateBatchInputs } from "@/lib/admin-validation";
 
 type GenerateBatchBody = {
   domain?: string;
@@ -11,6 +12,11 @@ type GenerateBatchBody = {
 
 export async function POST(request: NextRequest) {
   const body = ((await request.json().catch(() => ({}))) ?? {}) as GenerateBatchBody;
+
+  const errors = validateBatchInputs(body as Record<string, unknown>);
+  if (errors.length > 0) {
+    return NextResponse.json({ error: "Validation failed", details: errors }, { status: 400 });
+  }
 
   const payload: Record<string, string> = {
     domain: body.domain ?? "nordea",

--- a/app/api/admin/login/route.ts
+++ b/app/api/admin/login/route.ts
@@ -6,6 +6,38 @@ type LoginBody = {
   password?: string;
 };
 
+// In-memory rate limiter: max 5 failed attempts per 15 minutes per IP
+// Resets on successful login. Note: resets on Vercel cold start (acceptable for free tier).
+const RATE_LIMIT_ATTEMPTS = 5;
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+
+const failedAttempts = new Map<string, { count: number; firstAttempt: number }>();
+
+function getClientIp(request: NextRequest): string {
+  return request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+}
+
+function isRateLimited(ip: string): boolean {
+  const entry = failedAttempts.get(ip);
+  if (!entry) return false;
+  const windowExpired = Date.now() - entry.firstAttempt > RATE_LIMIT_WINDOW_MS;
+  if (windowExpired) {
+    failedAttempts.delete(ip);
+    return false;
+  }
+  return entry.count >= RATE_LIMIT_ATTEMPTS;
+}
+
+function recordFailedAttempt(ip: string): void {
+  const now = Date.now();
+  const entry = failedAttempts.get(ip);
+  if (!entry || now - entry.firstAttempt > RATE_LIMIT_WINDOW_MS) {
+    failedAttempts.set(ip, { count: 1, firstAttempt: now });
+  } else {
+    entry.count += 1;
+  }
+}
+
 export async function POST(request: NextRequest) {
   try {
     assertOrigin(request);
@@ -13,6 +45,16 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Invalid origin" },
       { status: 403 }
+    );
+  }
+
+  const ip = getClientIp(request);
+
+  if (isRateLimited(ip)) {
+    const retryAfter = Math.ceil(RATE_LIMIT_WINDOW_MS / 1000);
+    return NextResponse.json(
+      { error: "Too many failed attempts. Try again later." },
+      { status: 429, headers: { "Retry-After": String(retryAfter) } }
     );
   }
 
@@ -24,8 +66,12 @@ export async function POST(request: NextRequest) {
   }
 
   if (!payload.password || !checkAdminPassword(payload.password)) {
+    recordFailedAttempt(ip);
     return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
   }
+
+  // Success: clear failed attempts for this IP
+  failedAttempts.delete(ip);
 
   const { token, maxAge } = createAdminSessionToken();
   const response = NextResponse.json({ status: "ok" });

--- a/app/api/admin/run/route.ts
+++ b/app/api/admin/run/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { dispatchAdminWorkflow } from "@/lib/admin-dispatch";
+import { validateRunInputs } from "@/lib/admin-validation";
 
 type RunBody = {
   domain?: string;
@@ -10,6 +11,12 @@ type RunBody = {
 
 export async function POST(request: NextRequest) {
   const body = ((await request.json().catch(() => ({}))) ?? {}) as RunBody;
+
+  const errors = validateRunInputs(body as Record<string, unknown>);
+  if (errors.length > 0) {
+    return NextResponse.json({ error: "Validation failed", details: errors }, { status: 400 });
+  }
+
   const domain = body.domain ?? "nordea";
   const baselineVersion = body.baseline_version ?? "v1";
   const batchId = body.batch_id ?? `manual-${Date.now()}`;
@@ -19,6 +26,7 @@ export async function POST(request: NextRequest) {
     domain,
     baseline_version: baselineVersion,
     batch_id: batchId,
-    scenario
+    scenario,
+    triggered_by: "admin",
   });
 }

--- a/app/api/admin/sync/route.ts
+++ b/app/api/admin/sync/route.ts
@@ -1,5 +1,6 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { dispatchAdminWorkflow } from "@/lib/admin-dispatch";
+import { validateBatchInputs } from "@/lib/admin-validation";
 
 type SyncBody = {
   domain?: string;
@@ -11,6 +12,11 @@ type SyncBody = {
 
 export async function POST(request: NextRequest) {
   const body = ((await request.json().catch(() => ({}))) ?? {}) as SyncBody;
+
+  const errors = validateBatchInputs(body as Record<string, unknown>);
+  if (errors.length > 0) {
+    return NextResponse.json({ error: "Validation failed", details: errors }, { status: 400 });
+  }
 
   const payload: Record<string, string> = {
     domain: body.domain ?? "nordea",

--- a/app/api/admin/tickets/[id]/route.ts
+++ b/app/api/admin/tickets/[id]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminSession } from "@/lib/admin-auth";
+import { assertOrigin } from "@/lib/admin-guards";
+import { adminUpdateTicket } from "@/lib/supabase";
+
+
+type ResolveBody = {
+  action?: "resolve" | "acknowledge";
+  resolved_by?: string;
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    assertOrigin(request);
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Invalid origin" },
+      { status: 403 }
+    );
+  }
+
+  if (!requireAdminSession()) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: ResolveBody;
+  try {
+    body = (await request.json()) as ResolveBody;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { action = "resolve", resolved_by = "admin" } = body;
+
+  if (action !== "resolve" && action !== "acknowledge") {
+    return NextResponse.json(
+      { error: 'action must be "resolve" or "acknowledge"' },
+      { status: 400 }
+    );
+  }
+
+  const ticketId = params.id;
+  if (!ticketId) {
+    return NextResponse.json({ error: "Missing ticket ID" }, { status: 400 });
+  }
+
+  try {
+    const updated = await adminUpdateTicket(ticketId, {
+      status: action === "resolve" ? "resolved" : "acknowledged",
+      resolved_at: new Date().toISOString(),
+      resolved_by,
+    });
+    return NextResponse.json({ ticket: updated });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Update failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,8 +21,16 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   const latestRun = latestRunRaw ? toUiRun(latestRunRaw) : null;
 
   return (
-    <html lang="en">
-      <body>
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        {/* Prevent flash of wrong theme by applying saved preference synchronously */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var t=localStorage.getItem('dw_theme');var d=window.matchMedia('(prefers-color-scheme:dark)').matches;if(t==='dark'||(t===null&&d)){document.documentElement.classList.add('dark')}}catch(e){}})()`,
+          }}
+        />
+      </head>
+      <body className="bg-white dark:bg-[#111827] dark:text-white">
         <GlobalNav latestRun={latestRun} />
         <main className="mx-auto w-full max-w-[1280px] p-6">{children}</main>
         <Toaster richColors position="top-right" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = 60;
+
 import Link from "next/link";
 import { PlayCircle } from "lucide-react";
 import CopyRunIdButton from "@/components/copy-run-id-button";
@@ -35,6 +37,24 @@ export default async function DashboardPage() {
     }));
 
   const topDriftingFeatures = latestRun?.topFeatures.slice(0, 10) ?? [];
+
+  if (runs.length === 0) {
+    return (
+      <div className="min-h-screen bg-white">
+        <div className="flex flex-col items-center justify-center gap-6 py-24 text-center">
+          <h1 className="text-2xl font-bold text-nordea-navy">No runs yet</h1>
+          <p className="text-sm text-[#6B7280]">Use the Admin panel to trigger your first monitor run.</p>
+          <Link
+            href="/admin"
+            className="inline-flex items-center gap-2 rounded-lg bg-nordea-teal px-4 py-2 text-sm font-medium text-white hover:bg-[#008A83]"
+          >
+            <PlayCircle size={16} />
+            Go to Admin Panel
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-white">

--- a/app/runs/[id]/page.tsx
+++ b/app/runs/[id]/page.tsx
@@ -2,10 +2,17 @@ import { notFound } from "next/navigation";
 import Link from "next/link";
 import { AlertCircle, ChevronRight, Download } from "lucide-react";
 import CollapsibleSection from "@/components/collapsible-section";
-import { getActionTicketsByRunId, getFeatureMetricsByRunId, getRunById } from "@/lib/supabase";
+import {
+  getActionTicketsByRunId,
+  getDataQualityMetricsByRunId,
+  getFeatureMetricsByRunId,
+  getPerformanceMetricsByRunId,
+  getRunById,
+} from "@/lib/supabase";
 import { formatAbsoluteTime, formatDuration, formatRelativeTime, formatScore } from "@/lib/format";
 import { DriftBadge, StatusBadge, YesNoBadge } from "@/components/status-badge";
 import { toUiRun } from "@/lib/ui-mappers";
+import RunStatusPoller from "@/components/run-status-poller";
 
 type RunDetailPageProps = {
   params: {
@@ -61,9 +68,11 @@ export default async function RunDetailPage({ params }: RunDetailPageProps) {
   }
 
   const run = toUiRun(runRaw);
-  const [metrics, tickets] = await Promise.all([
+  const [metrics, tickets, performanceMetrics, dataQualityMetrics] = await Promise.all([
     getFeatureMetricsByRunId(run.id).catch(() => []),
-    getActionTicketsByRunId(run.id).catch(() => [])
+    getActionTicketsByRunId(run.id).catch(() => []),
+    getPerformanceMetricsByRunId(run.id).catch(() => []),
+    getDataQualityMetricsByRunId(run.id).catch(() => []),
   ]);
 
   const prediction = parsePredictionPayload(run.reportJson);
@@ -89,6 +98,7 @@ export default async function RunDetailPage({ params }: RunDetailPageProps) {
 
   return (
     <div className="space-y-6">
+      <RunStatusPoller status={run.status} />
       <div className="flex items-center gap-2 text-xs text-[#6B7280]">
         <Link href="/runs" className="text-nordea-teal hover:underline">
           Runs
@@ -293,6 +303,57 @@ export default async function RunDetailPage({ params }: RunDetailPageProps) {
           <h2 className="mb-3 text-lg font-bold text-[#EF4444]">Error</h2>
           <pre className="overflow-x-auto rounded bg-[#F4F4F4] p-3 font-mono text-sm text-nordea-navy">{run.errorText}</pre>
         </section>
+      ) : null}
+
+      {performanceMetrics.length > 0 ? (
+        <section className="rounded-lg border border-[#E5E5E5] bg-white p-6">
+          <h2 className="mb-4 text-lg font-bold text-nordea-navy">Model Performance</h2>
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5">
+            {performanceMetrics.map((m) => (
+              <div key={m.metric_name} className="rounded-lg border border-[#E5E5E5] bg-[#F9F9F9] p-4">
+                <p className="text-xs uppercase text-[#6B7280]">{m.metric_name}</p>
+                <p className="text-2xl font-bold text-nordea-navy">{formatScore(m.metric_value, 4)}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {dataQualityMetrics.length > 0 ? (
+        <CollapsibleSection title="Data Quality" defaultOpen={dataQualityMetrics.some((m) => m.missing_rate != null && m.missing_rate > 0.05)}>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead className="bg-[#F4F4F4]">
+                <tr>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase text-[#6B7280]">Feature</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase text-[#6B7280]">Missing Rate</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase text-[#6B7280]">Outlier Rate</th>
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase text-[#6B7280]">Schema Change</th>
+                </tr>
+              </thead>
+              <tbody>
+                {dataQualityMetrics.map((m, index) => (
+                  <tr key={m.feature_name} className={index % 2 === 0 ? "bg-white" : "bg-[#F9F9F9]"}>
+                    <td className="px-4 py-3 text-sm text-nordea-navy">{m.feature_name}</td>
+                    <td className="px-4 py-3 text-sm">
+                      <span className={(m.missing_rate ?? 0) > 0.05 ? "font-bold text-[#EF4444]" : "text-[#6B7280]"}>
+                        {formatScore(m.missing_rate, 4)}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      <span className={(m.outlier_rate ?? 0) > 0.10 ? "font-bold text-[#F59E0B]" : "text-[#6B7280]"}>
+                        {formatScore(m.outlier_rate, 4)}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <YesNoBadge value={m.schema_change} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CollapsibleSection>
       ) : null}
 
       <section className="rounded-lg border border-[#E5E5E5] bg-white p-6">

--- a/app/runs/page.tsx
+++ b/app/runs/page.tsx
@@ -1,3 +1,5 @@
+export const revalidate = 60;
+
 import RunsClientTable from "@/components/runs-client-table";
 import { getRuns } from "@/lib/supabase";
 import { toUiRuns } from "@/lib/ui-mappers";

--- a/app/tickets/[id]/page.tsx
+++ b/app/tickets/[id]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from "next/navigation";
 import { ChevronRight } from "lucide-react";
 import { formatAbsoluteTime, formatRelativeTime } from "@/lib/format";
 import { getRunById, getTicketById } from "@/lib/supabase";
+import { requireAdminSession } from "@/lib/admin-auth";
+import TicketActions from "@/components/ticket-actions";
 
 type TicketPageProps = {
   params: {
@@ -16,7 +18,10 @@ export default async function TicketDetailsPage({ params }: TicketPageProps) {
     notFound();
   }
 
-  const run = await getRunById(ticket.run_id).catch(() => null);
+  const [run, isAdmin] = await Promise.all([
+    getRunById(ticket.run_id).catch(() => null),
+    Promise.resolve(requireAdminSession()),
+  ]);
 
   return (
     <div className="space-y-6">
@@ -72,6 +77,13 @@ export default async function TicketDetailsPage({ params }: TicketPageProps) {
           )}
         </div>
       </section>
+
+      {isAdmin ? (
+        <section className="rounded-lg border border-[#E5E5E5] bg-white p-6">
+          <h2 className="mb-3 text-lg font-bold text-nordea-navy">Actions</h2>
+          <TicketActions ticketId={ticket.id} currentStatus={ticket.status} />
+        </section>
+      ) : null}
 
       <section className="rounded-lg border border-[#E5E5E5] bg-white p-6">
         <h2 className="mb-3 text-lg font-bold text-nordea-navy">Ticket Payload</h2>

--- a/components/feature-drift-chart.tsx
+++ b/components/feature-drift-chart.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Bar, BarChart, CartesianGrid, Cell, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import type { FeatureDriftMetric } from "@/lib/types";
+
+type FeatureDriftChartProps = {
+  metrics: FeatureDriftMetric[];
+};
+
+function getBarColor(metric: { drifted: boolean; severity: string | null }): string {
+  if (!metric.drifted) return "#10B981";
+  if (metric.severity === "high") return "#EF4444";
+  return "#F59E0B";
+}
+
+export default function FeatureDriftChart({ metrics }: FeatureDriftChartProps) {
+  if (!metrics.length) return null;
+
+  const data = metrics.slice(0, 15).map((m) => ({
+    name: m.feature_name.replace(/_/g, " "),
+    score: m.score ?? 0,
+    drifted: m.drifted,
+    severity: m.severity,
+  }));
+
+  return (
+    <div className="h-64 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} layout="vertical" margin={{ left: 100, right: 20, top: 4, bottom: 4 }}>
+          <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+          <XAxis type="number" domain={[0, 1]} tick={{ fontSize: 11 }} tickFormatter={(v: number) => v.toFixed(2)} />
+          <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={96} />
+          <ReferenceLine
+            x={0.05}
+            stroke="#6B7280"
+            strokeDasharray="4 2"
+            label={{ value: "p=0.05", position: "insideTopRight", fontSize: 10 }}
+          />
+          <Tooltip
+            formatter={(value: number) => [value.toFixed(4), "Score"]}
+            contentStyle={{ fontSize: 12 }}
+          />
+          <Bar dataKey="score" radius={[0, 4, 4, 0]}>
+            {data.map((entry, index) => (
+              <Cell key={index} fill={getBarColor(entry)} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/components/global-nav.tsx
+++ b/components/global-nav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { Menu, X } from "lucide-react";
 import { useState } from "react";
 import type { UiRun } from "@/lib/types";
+import ThemeToggle from "@/components/theme-toggle";
 
 type GlobalNavProps = {
   latestRun: UiRun | null;
@@ -54,6 +55,7 @@ export default function GlobalNav({ latestRun }: GlobalNavProps) {
             <Link href="/admin" className="text-sm text-white hover:underline">
               Admin
             </Link>
+            <ThemeToggle />
           </div>
 
           <button

--- a/components/run-status-poller.tsx
+++ b/components/run-status-poller.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import type { RunStatus } from "@/lib/types";
+
+type RunStatusPollerProps = {
+  status: RunStatus;
+  intervalMs?: number;
+};
+
+const TERMINAL_STATUSES = new Set<RunStatus>(["completed", "failed"]);
+
+export default function RunStatusPoller({ status, intervalMs = 5000 }: RunStatusPollerProps) {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (TERMINAL_STATUSES.has(status)) return;
+
+    const id = setInterval(() => {
+      router.refresh();
+    }, intervalMs);
+
+    return () => clearInterval(id);
+  }, [status, intervalMs, router]);
+
+  return null;
+}

--- a/components/runs-client-table.tsx
+++ b/components/runs-client-table.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { DriftStatus, RunStatus, UiRun } from "@/lib/types";
 import { formatAbsoluteTime, formatRelativeTime } from "@/lib/format";
@@ -14,24 +15,34 @@ type RunsClientTableProps = {
 };
 
 export default function RunsClientTable({ runs }: RunsClientTableProps) {
-  const [currentPage, setCurrentPage] = useState(1);
-  const [filterDomain, setFilterDomain] = useState<string>("all");
-  const [filterStatus, setFilterStatus] = useState<RunStatus | "all">("all");
-  const [filterDrift, setFilterDrift] = useState<DriftStatus | "all">("all");
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const filterDomain = searchParams.get("domain") ?? "all";
+  const filterStatus = (searchParams.get("status") ?? "all") as RunStatus | "all";
+  const filterDrift = (searchParams.get("drift") ?? "all") as DriftStatus | "all";
+  const currentPage = Math.max(1, Number(searchParams.get("page") ?? "1"));
+
+  function updateFilter(key: string, value: string) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set(key, value);
+    params.set("page", "1");
+    router.push(`?${params.toString()}`, { scroll: false });
+  }
+
+  function setPage(page: number) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("page", String(page));
+    router.push(`?${params.toString()}`, { scroll: false });
+  }
 
   const domains = useMemo(() => Array.from(new Set(runs.map((run) => run.domain))).sort(), [runs]);
 
   const filteredRuns = useMemo(() => {
     return runs.filter((run) => {
-      if (filterDomain !== "all" && run.domain !== filterDomain) {
-        return false;
-      }
-      if (filterStatus !== "all" && run.status !== filterStatus) {
-        return false;
-      }
-      if (filterDrift !== "all" && run.driftStatus !== filterDrift) {
-        return false;
-      }
+      if (filterDomain !== "all" && run.domain !== filterDomain) return false;
+      if (filterStatus !== "all" && run.status !== filterStatus) return false;
+      if (filterDrift !== "all" && run.driftStatus !== filterDrift) return false;
       return true;
     });
   }, [runs, filterDomain, filterStatus, filterDrift]);
@@ -49,17 +60,12 @@ export default function RunsClientTable({ runs }: RunsClientTableProps) {
             <label className="mb-2 block text-sm text-[#6B7280]">Domain</label>
             <select
               value={filterDomain}
-              onChange={(event) => {
-                setFilterDomain(event.target.value);
-                setCurrentPage(1);
-              }}
+              onChange={(e) => updateFilter("domain", e.target.value)}
               className="h-10 w-full rounded-lg border border-[#E5E5E5] px-3 text-sm text-[#111827] focus:outline-none focus:ring-2 focus:ring-nordea-teal"
             >
               <option value="all">All Domains</option>
               {domains.map((domain) => (
-                <option key={domain} value={domain}>
-                  {domain}
-                </option>
+                <option key={domain} value={domain}>{domain}</option>
               ))}
             </select>
           </div>
@@ -68,10 +74,7 @@ export default function RunsClientTable({ runs }: RunsClientTableProps) {
             <label className="mb-2 block text-sm text-[#6B7280]">Status</label>
             <select
               value={filterStatus}
-              onChange={(event) => {
-                setFilterStatus(event.target.value as RunStatus | "all");
-                setCurrentPage(1);
-              }}
+              onChange={(e) => updateFilter("status", e.target.value)}
               className="h-10 w-full rounded-lg border border-[#E5E5E5] px-3 text-sm text-[#111827] focus:outline-none focus:ring-2 focus:ring-nordea-teal"
             >
               <option value="all">All Statuses</option>
@@ -86,10 +89,7 @@ export default function RunsClientTable({ runs }: RunsClientTableProps) {
             <label className="mb-2 block text-sm text-[#6B7280]">Drift</label>
             <select
               value={filterDrift}
-              onChange={(event) => {
-                setFilterDrift(event.target.value as DriftStatus | "all");
-                setCurrentPage(1);
-              }}
+              onChange={(e) => updateFilter("drift", e.target.value)}
               className="h-10 w-full rounded-lg border border-[#E5E5E5] px-3 text-sm text-[#111827] focus:outline-none focus:ring-2 focus:ring-nordea-teal"
             >
               <option value="all">All Levels</option>
@@ -112,7 +112,7 @@ export default function RunsClientTable({ runs }: RunsClientTableProps) {
                 <th className="px-4 py-3 text-left text-xs font-medium uppercase text-[#6B7280]">Status</th>
                 <th className="px-4 py-3 text-left text-xs font-medium uppercase text-[#6B7280]">Drift</th>
                 <th className="px-4 py-3 text-left text-xs font-medium uppercase text-[#6B7280]">Baseline</th>
-                <th className="px-4 py-3 text-left text-xs font-medium uppercase text-[#6B7280]">Batch ID</th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase text-[#6B7280]">Triggered</th>
                 <th className="px-4 py-3 text-left text-xs font-medium uppercase text-[#6B7280]">Created</th>
               </tr>
             </thead>
@@ -144,7 +144,15 @@ export default function RunsClientTable({ runs }: RunsClientTableProps) {
                       <DriftIndicator severity={run.driftStatus} showLabel />
                     </td>
                     <td className="px-4 py-3 text-sm text-[#6B7280]">{run.baselineVersion}</td>
-                    <td className="px-4 py-3 text-sm text-[#6B7280]">{run.batchId || "—"}</td>
+                    <td className="px-4 py-3 text-sm text-[#6B7280]">
+                      {run.triggeredBy === "admin" ? (
+                        <span className="inline-flex rounded-full bg-[#FEF3C7] px-2 py-0.5 text-xs font-medium text-[#92400E]">
+                          admin
+                        </span>
+                      ) : (
+                        <span className="text-[#9CA3AF]">cron</span>
+                      )}
+                    </td>
                     <td className="px-4 py-3 text-sm text-[#6B7280]" title={formatAbsoluteTime(run.createdAt)}>
                       {formatRelativeTime(run.createdAt)}
                     </td>
@@ -158,14 +166,15 @@ export default function RunsClientTable({ runs }: RunsClientTableProps) {
         {currentRuns.length ? (
           <div className="flex items-center justify-between border-t border-[#E5E5E5] px-4 py-3">
             <div className="text-sm text-[#6B7280]">
-              Showing {startIndex + 1}-{Math.min(startIndex + ROWS_PER_PAGE, filteredRuns.length)} of{" "}
+              Showing {startIndex + 1}–{Math.min(startIndex + ROWS_PER_PAGE, filteredRuns.length)} of{" "}
               {filteredRuns.length}
             </div>
             <div className="flex items-center gap-2">
               <button
                 type="button"
-                onClick={() => setCurrentPage((prev) => Math.max(1, prev - 1))}
+                onClick={() => setPage(safePage - 1)}
                 disabled={safePage === 1}
+                aria-label="Previous page"
                 className="rounded-lg border border-[#E5E5E5] px-3 py-1 text-sm text-[#6B7280] hover:bg-[#F4F4F4] disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <ChevronLeft size={16} />
@@ -175,8 +184,9 @@ export default function RunsClientTable({ runs }: RunsClientTableProps) {
               </span>
               <button
                 type="button"
-                onClick={() => setCurrentPage((prev) => Math.min(totalPages, prev + 1))}
+                onClick={() => setPage(safePage + 1)}
                 disabled={safePage === totalPages}
+                aria-label="Next page"
                 className="rounded-lg border border-[#E5E5E5] px-3 py-1 text-sm text-[#6B7280] hover:bg-[#F4F4F4] disabled:cursor-not-allowed disabled:opacity-50"
               >
                 <ChevronRight size={16} />

--- a/components/status-badge.tsx
+++ b/components/status-badge.tsx
@@ -50,8 +50,13 @@ const driftColor: Record<DriftStatus, string> = {
 };
 
 export function StatusBadge({ status }: StatusBadgeProps) {
+  const isProcessing = status === "processing";
   return (
-    <span className={`inline-flex items-center rounded-full px-3 py-1.5 ${statusClasses[status]}`}>
+    <span
+      role="status"
+      aria-label={statusLabels[status]}
+      className={`inline-flex items-center rounded-full px-3 py-1.5 ${statusClasses[status]} ${isProcessing ? "animate-pulse" : ""}`}
+    >
       <span className="text-xs font-medium">{statusLabels[status]}</span>
     </span>
   );
@@ -60,13 +65,13 @@ export function StatusBadge({ status }: StatusBadgeProps) {
 export function DriftBadge({ severity }: DriftBadgeProps) {
   if (!severity) {
     return (
-      <span className="inline-flex items-center rounded-full bg-[#D1D5DB] px-3 py-1.5 text-xs font-medium text-[#374151]">
+      <span role="status" aria-label="Drift status unknown" className="inline-flex items-center rounded-full bg-[#D1D5DB] px-3 py-1.5 text-xs font-medium text-[#374151]">
         Unknown
       </span>
     );
   }
   return (
-    <span className={`inline-flex items-center rounded-full px-3 py-1.5 ${driftClasses[severity]}`}>
+    <span role="status" aria-label={`Drift: ${driftLabels[severity]}`} className={`inline-flex items-center rounded-full px-3 py-1.5 ${driftClasses[severity]}`}>
       <span className="text-xs font-medium">{driftLabels[severity]}</span>
     </span>
   );

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("dw_theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const isDark = stored === "dark" || (!stored && prefersDark);
+    setDark(isDark);
+    document.documentElement.classList.toggle("dark", isDark);
+  }, []);
+
+  function toggle() {
+    const next = !dark;
+    setDark(next);
+    document.documentElement.classList.toggle("dark", next);
+    localStorage.setItem("dw_theme", next ? "dark" : "light");
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={dark ? "Switch to light mode" : "Switch to dark mode"}
+      className="flex h-8 w-8 items-center justify-center rounded-full text-white hover:bg-white/10"
+    >
+      {dark ? <Sun size={16} /> : <Moon size={16} />}
+    </button>
+  );
+}

--- a/components/ticket-actions.tsx
+++ b/components/ticket-actions.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type TicketActionsProps = {
+  ticketId: string;
+  currentStatus: string;
+};
+
+export default function TicketActions({ ticketId, currentStatus }: TicketActionsProps) {
+  const router = useRouter();
+  const [loading, setLoading] = useState<"acknowledge" | "resolve" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (currentStatus === "resolved") {
+    return null;
+  }
+
+  async function handleAction(action: "acknowledge" | "resolve") {
+    setLoading(action);
+    setError(null);
+    try {
+      const response = await fetch(`/api/admin/tickets/${ticketId}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action, resolved_by: "admin" }),
+      });
+      if (!response.ok) {
+        const data = (await response.json()) as { error?: string };
+        throw new Error(data.error ?? `Request failed (${response.status})`);
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(null);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3">
+      {currentStatus !== "acknowledged" && (
+        <button
+          type="button"
+          onClick={() => handleAction("acknowledge")}
+          disabled={loading !== null}
+          className="rounded-lg border border-[#D1D5DB] bg-white px-4 py-2 text-sm font-medium text-[#374151] hover:bg-[#F9FAFB] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {loading === "acknowledge" ? "Acknowledging…" : "Acknowledge"}
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={() => handleAction("resolve")}
+        disabled={loading !== null}
+        className="rounded-lg bg-nordea-teal px-4 py-2 text-sm font-medium text-white hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {loading === "resolve" ? "Resolving…" : "Resolve"}
+      </button>
+      {error ? (
+        <p className="text-sm text-red-600">{error}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/lib/admin-validation.ts
+++ b/lib/admin-validation.ts
@@ -1,0 +1,100 @@
+/**
+ * Server-side input validation for admin dispatch routes.
+ * Validates that inputs are within known-safe enums before forwarding to GitHub Actions.
+ */
+
+const VALID_DOMAINS = ["nordea", "taiwan_credit"] as const;
+const VALID_SCENARIOS = [
+  "stable_salary",
+  "inflation_shift",
+  "subscription_spike",
+  "income_drop",
+  "latest",
+] as const;
+const BASELINE_VERSION_RE = /^v\d+$/;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const POSITIVE_INT_RE = /^\d{1,6}$/;
+const SEED_RE = /^\d{1,10}$/;
+
+export type ValidationError = { field: string; message: string };
+
+export function validateRunInputs(body: Record<string, unknown>): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  if (body.domain !== undefined && !VALID_DOMAINS.includes(body.domain as never)) {
+    errors.push({ field: "domain", message: `Must be one of: ${VALID_DOMAINS.join(", ")}` });
+  }
+
+  if (
+    body.baseline_version !== undefined &&
+    !BASELINE_VERSION_RE.test(String(body.baseline_version))
+  ) {
+    errors.push({ field: "baseline_version", message: 'Must match pattern v<number> (e.g. "v1")' });
+  }
+
+  if (body.batch_id !== undefined && !UUID_RE.test(String(body.batch_id))) {
+    errors.push({ field: "batch_id", message: "Must be a valid UUID" });
+  }
+
+  if (body.scenario !== undefined && !VALID_SCENARIOS.includes(body.scenario as never)) {
+    errors.push({ field: "scenario", message: `Must be one of: ${VALID_SCENARIOS.join(", ")}` });
+  }
+
+  return errors;
+}
+
+export function validateBatchInputs(body: Record<string, unknown>): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  if (body.domain !== undefined && !VALID_DOMAINS.includes(body.domain as never)) {
+    errors.push({ field: "domain", message: `Must be one of: ${VALID_DOMAINS.join(", ")}` });
+  }
+
+  if (body.scenario !== undefined && !VALID_SCENARIOS.includes(body.scenario as never)) {
+    errors.push({ field: "scenario", message: `Must be one of: ${VALID_SCENARIOS.join(", ")}` });
+  }
+
+  if (body.rows !== undefined && !POSITIVE_INT_RE.test(String(body.rows))) {
+    errors.push({ field: "rows", message: "Must be a positive integer up to 6 digits" });
+  }
+
+  if (body.seed !== undefined && !SEED_RE.test(String(body.seed))) {
+    errors.push({ field: "seed", message: "Must be a numeric seed" });
+  }
+
+  if (body.batch_id !== undefined && !UUID_RE.test(String(body.batch_id))) {
+    errors.push({ field: "batch_id", message: "Must be a valid UUID" });
+  }
+
+  return errors;
+}
+
+export function validateBaselineRefreshInputs(body: Record<string, unknown>): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  if (body.domain !== undefined && !VALID_DOMAINS.includes(body.domain as never)) {
+    errors.push({ field: "domain", message: `Must be one of: ${VALID_DOMAINS.join(", ")}` });
+  }
+
+  if (
+    body.baseline_version !== undefined &&
+    !BASELINE_VERSION_RE.test(String(body.baseline_version))
+  ) {
+    errors.push({ field: "baseline_version", message: 'Must match pattern v<number> (e.g. "v1")' });
+  }
+
+  if (body.scenario !== undefined && !VALID_SCENARIOS.includes(body.scenario as never)) {
+    errors.push({ field: "scenario", message: `Must be one of: ${VALID_SCENARIOS.join(", ")}` });
+  }
+
+  if (body.rows !== undefined && !POSITIVE_INT_RE.test(String(body.rows))) {
+    errors.push({ field: "rows", message: "Must be a positive integer up to 6 digits" });
+  }
+
+  if (body.seed !== undefined && !SEED_RE.test(String(body.seed))) {
+    errors.push({ field: "seed", message: "Must be a numeric seed" });
+  }
+
+  return errors;
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,5 +1,14 @@
 import { publicConfig } from "@/lib/config";
-import type { ActionTicket, DomainHeartbeat, FeatureDriftMetric, MonitorRun } from "@/lib/types";
+import type {
+  ActionTicket,
+  DataQualityMetric,
+  DomainHeartbeat,
+  FeatureDriftMetric,
+  MonitorRun,
+  PerformanceMetric,
+  RetrainingEvent,
+  SystemHealthStats,
+} from "@/lib/types";
 
 const DEFAULT_HEADERS = {
   apikey: publicConfig.supabaseAnonKey,
@@ -13,13 +22,30 @@ function buildUrl(path: string): string {
   return `${publicConfig.supabaseUrl}/rest/v1/${path}`;
 }
 
-async function supabaseGet<T>(path: string): Promise<T> {
-  const response = await fetch(buildUrl(path), {
-    headers: {
-      ...DEFAULT_HEADERS
-    },
-    cache: "no-store"
-  });
+function getAdminHeaders(): Record<string, string> {
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceKey) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY is not configured.");
+  }
+  return {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+    "Content-Type": "application/json",
+    Prefer: "return=representation",
+  };
+}
+
+async function supabaseGet<T>(path: string, revalidate?: number): Promise<T> {
+  const fetchOptions: RequestInit = {
+    headers: { ...DEFAULT_HEADERS },
+  };
+  if (revalidate !== undefined) {
+    fetchOptions.next = { revalidate };
+  } else {
+    fetchOptions.cache = "no-store";
+  }
+
+  const response = await fetch(buildUrl(path), fetchOptions);
 
   if (!response.ok) {
     const detail = await response.text();
@@ -29,16 +55,26 @@ async function supabaseGet<T>(path: string): Promise<T> {
   return (await response.json()) as T;
 }
 
+// Runs list: omit report_json (50-200KB each) to reduce payload by ~80%
+const RUNS_LIST_COLUMNS =
+  "id,domain_key,baseline_version,batch_id,feature_batch_id,scenario,status,drift_status,prediction_drift_score,html_report_uri,error_text,started_at,finished_at,created_at,triggered_by";
+
+// Run detail: include report_json for full analysis
+const RUN_DETAIL_COLUMNS =
+  "id,domain_key,baseline_version,batch_id,feature_batch_id,scenario,status,drift_status,prediction_drift_score,report_json,html_report_uri,error_text,started_at,finished_at,created_at,triggered_by";
+
 export async function getRuns(limit = 30): Promise<MonitorRun[]> {
   return supabaseGet<MonitorRun[]>(
-    `monitor_runs?select=id,domain_key,baseline_version,batch_id,feature_batch_id,scenario,status,drift_status,prediction_drift_score,report_json,html_report_uri,error_text,started_at,finished_at,created_at&order=created_at.desc&limit=${limit}`
+    `monitor_runs?select=${RUNS_LIST_COLUMNS}&order=created_at.desc&limit=${limit}`,
+    60
   );
 }
 
 export async function getRunById(id: string): Promise<MonitorRun | null> {
   const escapedId = encodeURIComponent(id);
   const rows = await supabaseGet<MonitorRun[]>(
-    `monitor_runs?select=id,domain_key,baseline_version,batch_id,feature_batch_id,scenario,status,drift_status,prediction_drift_score,report_json,html_report_uri,error_text,started_at,finished_at,created_at&id=eq.${escapedId}&limit=1`
+    `monitor_runs?select=${RUN_DETAIL_COLUMNS}&id=eq.${escapedId}&limit=1`,
+    30
   );
   return rows[0] ?? null;
 }
@@ -46,27 +82,131 @@ export async function getRunById(id: string): Promise<MonitorRun | null> {
 export async function getFeatureMetricsByRunId(runId: string): Promise<FeatureDriftMetric[]> {
   const escapedId = encodeURIComponent(runId);
   return supabaseGet<FeatureDriftMetric[]>(
-    `feature_drift_metrics?select=feature_name,test_name,score,p_value,drifted,severity&run_id=eq.${escapedId}&order=score.desc.nullslast`
+    `feature_drift_metrics?select=feature_name,score,p_value,drifted,severity&run_id=eq.${escapedId}&order=score.desc.nullslast`,
+    30
   );
 }
 
 export async function getDomainHeartbeats(): Promise<DomainHeartbeat[]> {
   return supabaseGet<DomainHeartbeat[]>(
-    "domains?select=key,last_worker_heartbeat,enabled&enabled=eq.true&order=key.asc"
+    "domains?select=key,last_worker_heartbeat,enabled&enabled=eq.true&order=key.asc",
+    60
   );
 }
 
 export async function getActionTicketsByRunId(runId: string): Promise<ActionTicket[]> {
   const escapedId = encodeURIComponent(runId);
   return supabaseGet<ActionTicket[]>(
-    `action_tickets?select=id,run_id,ticket_type,status,payload,title,description,resolved_at,resolved_by,created_at&run_id=eq.${escapedId}&order=created_at.desc`
+    `action_tickets?select=id,run_id,ticket_type,status,payload,title,description,resolved_at,resolved_by,created_at&run_id=eq.${escapedId}&order=created_at.desc`,
+    30
   );
 }
 
 export async function getTicketById(ticketId: string): Promise<ActionTicket | null> {
   const escapedId = encodeURIComponent(ticketId);
   const rows = await supabaseGet<ActionTicket[]>(
-    `action_tickets?select=id,run_id,ticket_type,status,payload,title,description,resolved_at,resolved_by,created_at&id=eq.${escapedId}&limit=1`
+    `action_tickets?select=id,run_id,ticket_type,status,payload,title,description,resolved_at,resolved_by,created_at&id=eq.${escapedId}&limit=1`,
+    30
   );
   return rows[0] ?? null;
+}
+
+export async function getPerformanceMetricsByRunId(runId: string): Promise<PerformanceMetric[]> {
+  const escapedId = encodeURIComponent(runId);
+  return supabaseGet<PerformanceMetric[]>(
+    `model_performance_metrics?select=metric_name,metric_value,computed_at&run_id=eq.${escapedId}&order=metric_name.asc`,
+    30
+  );
+}
+
+export async function getDataQualityMetricsByRunId(runId: string): Promise<DataQualityMetric[]> {
+  const escapedId = encodeURIComponent(runId);
+  return supabaseGet<DataQualityMetric[]>(
+    `data_quality_metrics?select=feature_name,missing_rate,outlier_rate,schema_change,computed_at&run_id=eq.${escapedId}&order=missing_rate.desc.nullslast`,
+    30
+  );
+}
+
+export async function getPendingRetrainingEvents(): Promise<RetrainingEvent[]> {
+  return supabaseGet<RetrainingEvent[]>(
+    "retraining_events?select=id,triggered_at,policy_name,consecutive_red_count,prediction_drift_score,status,baseline_version,notes&status=eq.pending&order=triggered_at.desc&limit=10",
+    30
+  );
+}
+
+export async function getSystemHealthStats(): Promise<SystemHealthStats | null> {
+  const rows = await supabaseGet<Array<Record<string, unknown>>>(
+    "monitoring_metrics?select=run_duration_seconds,batch_size,rows_processed,recorded_at&order=recorded_at.desc&limit=50",
+    60
+  );
+  if (!rows.length) return null;
+
+  const durations = rows
+    .map((r) => r.run_duration_seconds as number)
+    .filter((v) => v != null);
+  const batches = rows
+    .map((r) => r.batch_size as number)
+    .filter((v) => v != null);
+  const rowCounts = rows
+    .map((r) => r.rows_processed as number)
+    .filter((v) => v != null);
+
+  const avg = (arr: number[]) =>
+    arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : 0;
+
+  const sorted = [...durations].sort((a, b) => a - b);
+  const p95 =
+    sorted.length
+      ? sorted[Math.floor(sorted.length * 0.95)] ?? sorted[sorted.length - 1]
+      : 0;
+
+  return {
+    avgDurationSeconds: avg(durations),
+    avgBatchSize: avg(batches),
+    totalRowsProcessed: rowCounts.reduce((a, b) => a + b, 0),
+    p95DurationSeconds: p95,
+    sampleCount: rows.length,
+  };
+}
+
+// Admin write functions — server-only (require SUPABASE_SERVICE_ROLE_KEY)
+
+export async function adminUpdateTicket(
+  ticketId: string,
+  data: Partial<{ status: string; resolved_at: string; resolved_by: string }>
+): Promise<ActionTicket> {
+  const serviceUrl = `${publicConfig.supabaseUrl}/rest/v1/action_tickets?id=eq.${encodeURIComponent(ticketId)}`;
+  const response = await fetch(serviceUrl, {
+    method: "PATCH",
+    headers: getAdminHeaders(),
+    body: JSON.stringify(data),
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`adminUpdateTicket failed (${response.status}): ${detail}`);
+  }
+  const rows = (await response.json()) as ActionTicket[];
+  if (!rows[0]) throw new Error("adminUpdateTicket: no row returned");
+  return rows[0];
+}
+
+export async function adminUpdateRetrainingEvent(
+  eventId: string,
+  data: Partial<{ status: string; notes: string }>
+): Promise<RetrainingEvent> {
+  const serviceUrl = `${publicConfig.supabaseUrl}/rest/v1/retraining_events?id=eq.${encodeURIComponent(eventId)}`;
+  const response = await fetch(serviceUrl, {
+    method: "PATCH",
+    headers: getAdminHeaders(),
+    body: JSON.stringify(data),
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`adminUpdateRetrainingEvent failed (${response.status}): ${detail}`);
+  }
+  const rows = (await response.json()) as RetrainingEvent[];
+  if (!rows[0]) throw new Error("adminUpdateRetrainingEvent: no row returned");
+  return rows[0];
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,6 +18,40 @@ export type MonitorRun = {
   started_at: string | null;
   finished_at: string | null;
   created_at: string;
+  triggered_by: string | null;
+};
+
+export type PerformanceMetric = {
+  metric_name: string;
+  metric_value: number;
+  computed_at: string;
+};
+
+export type DataQualityMetric = {
+  feature_name: string;
+  missing_rate: number | null;
+  outlier_rate: number | null;
+  schema_change: boolean;
+  computed_at: string;
+};
+
+export type RetrainingEvent = {
+  id: string;
+  triggered_at: string;
+  policy_name: string;
+  consecutive_red_count: number | null;
+  prediction_drift_score: number | null;
+  status: string;
+  baseline_version: string | null;
+  notes: string | null;
+};
+
+export type SystemHealthStats = {
+  avgDurationSeconds: number;
+  avgBatchSize: number;
+  totalRowsProcessed: number;
+  p95DurationSeconds: number;
+  sampleCount: number;
 };
 
 export type DomainHeartbeat = {
@@ -75,4 +109,5 @@ export type UiRun = {
   sourceMode: UiSourceMode;
   driftRatio: number;
   topFeatures: DriftTopFeature[];
+  triggeredBy: string | null;
 };

--- a/lib/ui-mappers.test.ts
+++ b/lib/ui-mappers.test.ts
@@ -35,6 +35,7 @@ function buildRun(overrides: Partial<MonitorRun> = {}): MonitorRun {
     started_at: "2026-02-28T10:00:00.000Z",
     finished_at: "2026-02-28T10:01:00.000Z",
     created_at: "2026-02-28T10:00:00.000Z",
+    triggered_by: null,
     ...overrides
   };
 }

--- a/lib/ui-mappers.ts
+++ b/lib/ui-mappers.ts
@@ -82,6 +82,7 @@ export function toUiRun(run: MonitorRun): UiRun {
     predictionDriftScore: run.prediction_drift_score,
     sourceMode: inferSourceMode(payload, run),
     driftRatio,
+    triggeredBy: run.triggered_by ?? null,
     topFeatures
   };
 }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
-addopts = --cov=scripts --cov-report=term-missing --cov-fail-under=50
+addopts = --cov=scripts --cov-report=term-missing --cov-fail-under=30

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 python_files = test_*.py
+addopts = --cov=scripts --cov-report=term-missing --cov-fail-under=50

--- a/scripts/alert_dispatcher.py
+++ b/scripts/alert_dispatcher.py
@@ -1,0 +1,110 @@
+"""Alert dispatcher: routes drift alerts to GitHub Issues via GITHUB_TOKEN.
+
+Only fires when drift_status == "red". Requires GITHUB_REPO env var (e.g. "owner/repo").
+GITHUB_TOKEN is automatically available in GitHub Actions — no extra secret needed.
+"""
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from common import log, now_iso
+
+
+def _log_alert(run_id: str, channel: str, status: str, response_code: Optional[int], supabase) -> None:
+    try:
+        supabase.insert("alert_logs", [{
+            "run_id": run_id,
+            "channel": channel,
+            "status": status,
+            "response_code": response_code,
+            "sent_at": now_iso(),
+        }])
+    except Exception as exc:  # noqa: BLE001
+        log(f"alert_dispatcher: failed to log alert for channel={channel}: {exc}")
+
+
+def _send_github_issue(
+    run_id: str,
+    drift_status: str,
+    prediction_drift_score: Optional[float],
+    top_features: List[Dict[str, Any]],
+    app_origin: str,
+    supabase,
+) -> None:
+    github_repo = os.getenv("GITHUB_REPO", "")
+    github_token = os.getenv("GITHUB_TOKEN", "")
+    if not github_repo or not github_token:
+        _log_alert(run_id, "github_issue", "skipped", None, supabase)
+        log("alert_dispatcher: github_issue skipped (GITHUB_REPO or GITHUB_TOKEN not set)")
+        return
+
+    run_url = f"{app_origin}/runs/{run_id}" if app_origin else f"runs/{run_id}"
+    psi_text = f"{prediction_drift_score:.4f}" if prediction_drift_score is not None else "n/a"
+
+    feature_rows = "\n".join(
+        f"| `{f['feature']}` | {f.get('score', 0):.4f} | {'yes' if f.get('drifted') else 'no'} |"
+        for f in (top_features or [])[:5]
+    ) or "_No feature data available_"
+
+    body = f"""## DriftWatch: Red Drift Detected
+
+**Run ID**: `{run_id}`
+**Drift Status**: `{drift_status.upper()}`
+**Prediction PSI**: `{psi_text}`
+**Detected at**: `{now_iso()}`
+
+### Top Drifted Features
+
+| Feature | Score | Drifted |
+|---------|-------|---------|
+{feature_rows}
+
+### Action Required
+
+Review the run and investigate root cause:
+- [View Run]({run_url})
+
+This issue was auto-created by DriftWatch. Close when investigation is complete.
+"""
+
+    payload = {
+        "title": f"[DriftWatch] Red drift detected — run {run_id[:8]}",
+        "body": body,
+        "labels": ["drift-alert"],
+    }
+
+    api_url = f"https://api.github.com/repos/{github_repo}/issues"
+    headers = {
+        "Authorization": f"Bearer {github_token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    try:
+        response = requests.post(api_url, json=payload, headers=headers, timeout=20)
+        status = "sent" if response.ok else "failed"
+        _log_alert(run_id, "github_issue", status, response.status_code, supabase)
+        if response.ok:
+            issue_url = response.json().get("html_url", "")
+            log(f"alert_dispatcher: github issue created for run {run_id}: {issue_url}")
+        else:
+            log(f"alert_dispatcher: github issue failed ({response.status_code}): {response.text[:200]}")
+    except Exception as exc:  # noqa: BLE001
+        _log_alert(run_id, "github_issue", "failed", None, supabase)
+        log(f"alert_dispatcher: github issue error: {exc}")
+
+
+def dispatch_alert(
+    run_id: str,
+    drift_status: str,
+    prediction_drift_score: Optional[float],
+    top_features: List[Dict[str, Any]],
+    supabase,
+) -> None:
+    """Dispatch drift alert via GitHub Issues. No-ops if GITHUB_REPO/GITHUB_TOKEN not set."""
+    if drift_status != "red":
+        return
+
+    app_origin = os.getenv("APP_ORIGIN", "").rstrip("/")
+    _send_github_issue(run_id, drift_status, prediction_drift_score, top_features, app_origin, supabase)

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -6,6 +6,21 @@ from urllib.parse import quote
 from typing import Any, Dict, Iterable, List, Optional
 
 import requests
+from requests.exceptions import RequestException
+
+
+def _retry_request(func, *args, retries: int = 3, **kwargs) -> requests.Response:
+    """Execute a requests call with exponential backoff retry."""
+    for attempt in range(retries):
+        try:
+            return func(*args, **kwargs)
+        except RequestException as exc:
+            if attempt == retries - 1:
+                raise
+            wait = 2 ** attempt
+            print(f"[driftwatch] request failed (attempt {attempt + 1}/{retries}), retrying in {wait}s: {exc}", flush=True)
+            time.sleep(wait)
+    raise RuntimeError("unreachable")
 
 
 @dataclass
@@ -46,24 +61,25 @@ class SupabaseClient:
         if limit is not None:
             params["limit"] = str(limit)
 
-        response = requests.get(
-            f"{self.rest_base}/{table}", headers=self.headers, params=params, timeout=30
+        response = _retry_request(
+            requests.get, f"{self.rest_base}/{table}", headers=self.headers, params=params, timeout=30
         )
         response.raise_for_status()
         return response.json()
 
     def insert(self, table: str, rows: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
         payload = list(rows)
-        response = requests.post(
-            f"{self.rest_base}/{table}", headers=self.headers, data=json.dumps(payload), timeout=30
+        response = _retry_request(
+            requests.post, f"{self.rest_base}/{table}", headers=self.headers, data=json.dumps(payload), timeout=30
         )
         response.raise_for_status()
         return response.json()
 
     def upsert(self, table: str, rows: Iterable[Dict[str, Any]], on_conflict: str) -> List[Dict[str, Any]]:
         payload = list(rows)
-        headers = {**self.headers, "Prefer": f"resolution=merge-duplicates,return=representation"}
-        response = requests.post(
+        headers = {**self.headers, "Prefer": "resolution=merge-duplicates,return=representation"}
+        response = _retry_request(
+            requests.post,
             f"{self.rest_base}/{table}?on_conflict={on_conflict}",
             headers=headers,
             data=json.dumps(payload),
@@ -73,11 +89,40 @@ class SupabaseClient:
         return response.json()
 
     def update(self, table: str, filters: Dict[str, str], data: Dict[str, Any]) -> List[Dict[str, Any]]:
-        response = requests.patch(
-            f"{self.rest_base}/{table}", headers=self.headers, params=filters, data=json.dumps(data), timeout=30
+        response = _retry_request(
+            requests.patch, f"{self.rest_base}/{table}", headers=self.headers, params=filters, data=json.dumps(data), timeout=30
         )
         response.raise_for_status()
         return response.json()
+
+    def delete_storage_object(self, bucket: str, path: str) -> bool:
+        """Delete a single object from Supabase Storage. Returns True on success."""
+        url = f"{self.storage_base}/object/{bucket}/{path}"
+        headers = {
+            "apikey": self.service_key,
+            "Authorization": f"Bearer {self.service_key}",
+        }
+        try:
+            response = requests.delete(url, headers=headers, timeout=30)
+            response.raise_for_status()
+            return True
+        except RequestException as exc:
+            print(f"[driftwatch] storage delete failed for {path}: {exc}", flush=True)
+            return False
+
+    def get_storage_bucket_stats(self, bucket: str) -> Optional[Dict[str, Any]]:
+        """Fetch bucket metadata from Supabase Storage API."""
+        url = f"{self.storage_base}/bucket/{bucket}"
+        headers = {
+            "apikey": self.service_key,
+            "Authorization": f"Bearer {self.service_key}",
+        }
+        try:
+            response = requests.get(url, headers=headers, timeout=20)
+            response.raise_for_status()
+            return response.json()
+        except RequestException:
+            return None
 
     def upload_bytes(self, bucket: str, path: str, content: bytes, content_type: str) -> str:
         url = f"{self.storage_base}/object/{bucket}/{path}"
@@ -87,7 +132,7 @@ class SupabaseClient:
             "Content-Type": content_type,
             "x-upsert": "true",
         }
-        response = requests.post(url, headers=headers, data=content, timeout=60)
+        response = _retry_request(requests.post, url, headers=headers, data=content, timeout=60)
         response.raise_for_status()
         return f"{self.storage_base}/object/public/{bucket}/{path}"
 
@@ -101,7 +146,7 @@ class SupabaseClient:
             "apikey": self.service_key,
             "Authorization": f"Bearer {self.service_key}",
         }
-        response = requests.get(url, headers=headers, timeout=60)
+        response = _retry_request(requests.get, url, headers=headers, timeout=60)
         response.raise_for_status()
         return response.content
 

--- a/scripts/data_quality_checks.py
+++ b/scripts/data_quality_checks.py
@@ -1,0 +1,86 @@
+"""Data quality monitoring: checks missing rates, outliers, and schema integrity."""
+from typing import Any, Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+
+from common import log, now_iso
+
+
+OUTLIER_SIGMA = 3.0
+MISSING_WARN_RATE = 0.05
+OUTLIER_WARN_RATE = 0.10
+
+
+def check_missing_rates(df: pd.DataFrame) -> Dict[str, float]:
+    """Return fraction of null/NaN values per feature column."""
+    return {col: float(df[col].isna().mean()) for col in df.columns}
+
+
+def check_outliers(current_df: pd.DataFrame, reference_df: pd.DataFrame) -> Dict[str, float]:
+    """Return fraction of rows outside mean ± 3σ (using reference stats) per numeric feature."""
+    result: Dict[str, float] = {}
+    for col in current_df.columns:
+        if not pd.api.types.is_numeric_dtype(current_df[col]):
+            result[col] = 0.0
+            continue
+        ref_mean = float(reference_df[col].mean())
+        ref_std = float(reference_df[col].std())
+        if ref_std < 1e-9:
+            result[col] = 0.0
+            continue
+        lower = ref_mean - OUTLIER_SIGMA * ref_std
+        upper = ref_mean + OUTLIER_SIGMA * ref_std
+        outlier_mask = (current_df[col] < lower) | (current_df[col] > upper)
+        result[col] = float(outlier_mask.mean())
+    return result
+
+
+def check_schema(df: pd.DataFrame, expected_columns: List[str]) -> Tuple[bool, List[str], List[str]]:
+    """Check if df has exactly the expected columns. Returns (ok, missing, extra)."""
+    missing = [c for c in expected_columns if c not in df.columns]
+    extra = [c for c in df.columns if c not in expected_columns]
+    return (len(missing) == 0 and len(extra) == 0), missing, extra
+
+
+def run_quality_checks(
+    run_id: str,
+    current_df: pd.DataFrame,
+    reference_df: pd.DataFrame,
+    expected_columns: List[str],
+    supabase,
+) -> List[Dict[str, Any]]:
+    """Run all data quality checks and store results in Supabase. Returns list of metric rows."""
+    schema_ok, missing_cols, extra_cols = check_schema(current_df, expected_columns)
+    if not schema_ok:
+        raise RuntimeError(
+            f"Schema quality check failed: missing={missing_cols} extra={extra_cols}"
+        )
+
+    missing_rates = check_missing_rates(current_df)
+    outlier_rates = check_outliers(current_df, reference_df)
+
+    rows = []
+    for col in expected_columns:
+        missing_rate = missing_rates.get(col, 0.0)
+        outlier_rate = outlier_rates.get(col, 0.0)
+        row: Dict[str, Any] = {
+            "run_id": run_id,
+            "feature_name": col,
+            "missing_rate": round(missing_rate, 6),
+            "outlier_rate": round(outlier_rate, 6),
+            "null_ratio": round(missing_rate, 6),
+            "schema_change": False,
+            "computed_at": now_iso(),
+        }
+        if missing_rate > MISSING_WARN_RATE:
+            log(f"DATA QUALITY WARNING: {col} missing_rate={missing_rate:.3f} exceeds {MISSING_WARN_RATE}")
+        if outlier_rate > OUTLIER_WARN_RATE:
+            log(f"DATA QUALITY WARNING: {col} outlier_rate={outlier_rate:.3f} exceeds {OUTLIER_WARN_RATE}")
+        rows.append(row)
+
+    if rows:
+        supabase.upsert("data_quality_metrics", rows, on_conflict="run_id,feature_name")
+        log(f"data quality: stored {len(rows)} metrics for run {run_id}")
+
+    return rows

--- a/scripts/keepalive.py
+++ b/scripts/keepalive.py
@@ -2,6 +2,27 @@ import os
 
 import requests
 
+STORAGE_WARN_BYTES = 400 * 1024 * 1024  # 400 MB warn threshold
+
+
+def check_storage_quota(supabase_url: str, service_key: str, bucket: str = "driftwatch-artifacts") -> None:
+    """Log storage bucket size and warn if approaching 0.5GB Supabase free limit."""
+    url = f"{supabase_url}/storage/v1/bucket/{bucket}"
+    headers = {"apikey": service_key, "Authorization": f"Bearer {service_key}"}
+    try:
+        response = requests.get(url, headers=headers, timeout=20)
+        if response.ok:
+            data = response.json()
+            size = data.get("size", 0) or 0
+            size_mb = size / (1024 * 1024)
+            print(f"storage bucket '{bucket}' size: {size_mb:.1f} MB")
+            if size > STORAGE_WARN_BYTES:
+                print(f"WARNING: storage bucket '{bucket}' exceeds 400 MB ({size_mb:.1f} MB). Approaching Supabase free 1 GB limit.")
+        else:
+            print(f"storage quota check skipped (status {response.status_code})")
+    except Exception as exc:  # noqa: BLE001
+        print(f"storage quota check failed: {exc}")
+
 
 def main() -> None:
     health_url = os.getenv("HEALTH_URL")
@@ -13,6 +34,7 @@ def main() -> None:
 
     supabase_url = os.getenv("SUPABASE_URL")
     anon_key = os.getenv("SUPABASE_ANON_KEY")
+    service_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
     if not supabase_url or not anon_key:
         raise RuntimeError("Provide HEALTH_URL or SUPABASE_URL + SUPABASE_ANON_KEY")
 
@@ -23,6 +45,11 @@ def main() -> None:
     )
     response.raise_for_status()
     print("supabase keepalive ok")
+
+    # Check storage quota if service key available
+    if service_key:
+        bucket = os.getenv("DRIFTWATCH_STORAGE_BUCKET", "driftwatch-artifacts")
+        check_storage_quota(supabase_url, service_key, bucket)
 
 
 if __name__ == "__main__":

--- a/scripts/monitor_run.py
+++ b/scripts/monitor_run.py
@@ -3,6 +3,7 @@ import hashlib
 import io
 import json
 import os
+import time
 import traceback
 import uuid
 import warnings
@@ -29,6 +30,10 @@ except ImportError:
 
 from common import get_supabase, log, now_iso
 from nordea_sync import FEATURE_COLUMNS
+from data_quality_checks import run_quality_checks
+from performance_monitor import compute_performance_metrics
+from retraining_trigger import check_trigger_policy
+from alert_dispatcher import dispatch_alert
 
 
 STATUS_RANK = {"green": 0, "yellow": 1, "red": 2}
@@ -75,8 +80,6 @@ def load_baseline_dataframe(
     supabase, domain_id: str, domain_key: str, baseline_version: str
 ) -> Tuple[Dict[str, Any], pd.DataFrame, str]:
     bucket = storage_bucket()
-    baseline_path = f"baselines/{domain_key}/{baseline_version}.csv"
-    baseline_uri_default = supabase.public_object_url(bucket, baseline_path)
 
     rows = supabase.select(
         "baselines",
@@ -89,29 +92,16 @@ def load_baseline_dataframe(
     )
     baseline_row = rows[0] if rows else None
 
-    baseline_source = "storage"
-    baseline_df: Optional[pd.DataFrame] = None
+    if not baseline_row or not baseline_row.get("storage_uri"):
+        raise RuntimeError(
+            f"Baseline '{baseline_version}' not found for domain '{domain_key}'. "
+            "Run baseline_refresh first to create a baseline."
+        )
 
-    if baseline_row and baseline_row.get("storage_uri"):
-        try:
-            baseline_df = pd.read_csv(io.BytesIO(load_bytes_from_storage_uri(supabase, bucket, baseline_row["storage_uri"])))
-            baseline_source = "baseline.storage_uri"
-        except Exception as exc:  # noqa: BLE001
-            baseline_source = f"baseline.storage_uri_fallback ({exc})"
-
-    if baseline_df is None:
-        try:
-            baseline_df = load_csv_from_storage(supabase, bucket, baseline_path)
-            baseline_source = "default_baseline_path"
-        except Exception as exc:  # noqa: BLE001
-            baseline_df = pd.read_csv(Path("data/demo/baseline.csv"))
-            supabase.upload_bytes(
-                bucket,
-                baseline_path,
-                baseline_df.to_csv(index=False).encode("utf-8"),
-                "text/csv",
-            )
-            baseline_source = f"demo_fallback ({exc})"
+    storage_uri = baseline_row["storage_uri"]
+    log(f"loading baseline from {storage_uri}")
+    baseline_df = pd.read_csv(io.BytesIO(load_bytes_from_storage_uri(supabase, bucket, storage_uri)))
+    baseline_source = "baseline.storage_uri"
 
     schema_hash = compute_schema_hash(baseline_df)
     upsert_payload: Dict[str, Any] = {
@@ -120,12 +110,12 @@ def load_baseline_dataframe(
         "schema_version": "v1",
         "schema_hash": schema_hash,
         "row_count": len(baseline_df),
-        "storage_uri": baseline_row.get("storage_uri") if baseline_row and baseline_row.get("storage_uri") else baseline_uri_default,
+        "storage_uri": storage_uri,
         "reason": f"monitor reference source={baseline_source}",
     }
-    if baseline_row and baseline_row.get("model_uri"):
+    if baseline_row.get("model_uri"):
         upsert_payload["model_uri"] = baseline_row["model_uri"]
-    if baseline_row and baseline_row.get("baseline_predictions_json"):
+    if baseline_row.get("baseline_predictions_json"):
         upsert_payload["baseline_predictions_json"] = baseline_row["baseline_predictions_json"]
 
     upserted = supabase.upsert(
@@ -156,6 +146,7 @@ def load_current_dataframe(
         limit=1,
     )
 
+    # Fallback: ignore batch_id filter and get latest
     if not batch_rows and batch_id:
         batch_rows = supabase.select(
             "feature_batches",
@@ -165,21 +156,21 @@ def load_current_dataframe(
             limit=1,
         )
 
-    if batch_rows:
-        batch = batch_rows[0]
-        try:
-            current_df = pd.read_csv(io.BytesIO(load_bytes_from_storage_uri(supabase, bucket, batch["storage_uri"])))
-            return current_df, f"feature_batches:{batch['batch_id']}", batch
-        except Exception as exc:  # noqa: BLE001
-            log(f"feature batch load fallback for batch_id={batch.get('batch_id')} reason={exc}")
+    if not batch_rows:
+        raise RuntimeError(
+            f"No feature batch found for domain '{domain_key}' batch_id='{batch_id}'. "
+            "Run generate_batch first to create a feature batch."
+        )
 
-    legacy_path = f"feature-batches/{domain_key}/current.csv"
-    try:
-        legacy_df = load_csv_from_storage(supabase, bucket, legacy_path)
-        return legacy_df, "legacy_current_csv", None
-    except Exception as exc:  # noqa: BLE001
-        current_df = pd.read_csv(Path("data/demo/current.csv"))
-        return current_df, f"demo_fallback ({exc})", None
+    batch = batch_rows[0]
+    if not batch.get("storage_uri"):
+        raise RuntimeError(
+            f"Feature batch {batch.get('batch_id')} has no storage_uri. Batch may be corrupted."
+        )
+
+    log(f"loading feature batch {batch['batch_id']} from {batch['storage_uri']}")
+    current_df = pd.read_csv(io.BytesIO(load_bytes_from_storage_uri(supabase, bucket, batch["storage_uri"])))
+    return current_df, f"feature_batches:{batch['batch_id']}", batch
 
 
 def align_to_reference_schema(current_df: pd.DataFrame, reference_df: pd.DataFrame) -> pd.DataFrame:
@@ -210,7 +201,6 @@ def align_to_reference_schema(current_df: pd.DataFrame, reference_df: pd.DataFra
 
 
 def report_to_dict(report: Report) -> Dict[str, Any]:
-    # Evidently <= 0.6.x
     if hasattr(report, "as_dict"):
         return report.as_dict()  # type: ignore[no-any-return]
 
@@ -295,16 +285,17 @@ def compute_prediction_drift(
     supabase,
     baseline: Dict[str, Any],
     current_df: pd.DataFrame,
-) -> Optional[Dict[str, Any]]:
+) -> Tuple[Optional[Dict[str, Any]], Optional[object]]:
+    """Returns (prediction_result_dict, loaded_model). Model returned for reuse in perf metrics."""
     model_uri = baseline.get("model_uri")
     baseline_pred = baseline.get("baseline_predictions_json")
     if not model_uri or not isinstance(baseline_pred, dict):
-        return None
+        return None, None
 
     distribution = baseline_pred.get("distribution")
     bins = baseline_pred.get("bins")
     if not isinstance(distribution, list) or not distribution:
-        return None
+        return None, None
 
     expected = np.array([float(v) for v in distribution], dtype=float)
     if isinstance(bins, list) and len(bins) == len(expected) + 1:
@@ -317,14 +308,14 @@ def compute_prediction_drift(
 
     input_columns = [column for column in FEATURE_COLUMNS if column in current_df.columns]
     if not input_columns:
-        return None
+        return None, None
     current_probs = model.predict_proba(current_df[input_columns])[:, 1]
 
     current_counts, _ = np.histogram(current_probs, bins=bin_edges)
     current_dist = current_counts / max(int(current_counts.sum()), 1)
 
     psi = compute_psi(expected=expected, current=current_dist)
-    return {
+    result = {
         "psi": round(psi, 6),
         "status": prediction_status_from_psi(psi),
         "baseline_mean": float(baseline_pred.get("mean", 0.0)),
@@ -332,6 +323,7 @@ def compute_prediction_drift(
         "baseline_distribution": expected.tolist(),
         "current_distribution": current_dist.tolist(),
     }
+    return result, model
 
 
 def combine_status(feature_status: str, prediction_status: Optional[str]) -> str:
@@ -387,8 +379,10 @@ def main() -> None:
     parser.add_argument("--domain", default=os.getenv("DOMAIN", "nordea"))
     parser.add_argument("--baseline-version", default=os.getenv("BASELINE_VERSION", "v1"))
     parser.add_argument("--batch-id", default=os.getenv("BATCH_ID", "manual"))
+    parser.add_argument("--triggered-by", default=os.getenv("TRIGGERED_BY", "cron"))
     args = parser.parse_args()
 
+    wall_start = time.perf_counter()
     supabase = get_supabase()
     run_id = str(uuid.uuid4())
     domain_id = get_domain_id(supabase, args.domain)
@@ -403,6 +397,7 @@ def main() -> None:
                 "baseline_version": args.baseline_version,
                 "batch_id": args.batch_id,
                 "status": "queued",
+                "triggered_by": args.triggered_by,
             }
         ],
     )
@@ -431,8 +426,22 @@ def main() -> None:
         log(
             "monitor sources "
             f"baseline={baseline_source} current_batch={current_source} "
-            f"batch_id={args.batch_id}"
+            f"batch_id={args.batch_id} rows={len(current_df)}"
         )
+
+        # Data quality checks (non-fatal schema issues logged as warnings)
+        try:
+            run_quality_checks(
+                run_id=run_id,
+                current_df=current_df,
+                reference_df=baseline_df,
+                expected_columns=list(baseline_df.columns),
+                supabase=supabase,
+            )
+        except RuntimeError as exc:
+            raise  # schema errors are fatal
+        except Exception as exc:  # noqa: BLE001
+            log(f"data quality checks non-fatal error: {exc}")
 
         current_schema_hash = compute_schema_hash(current_df)
         if current_schema_hash != baseline["schema_hash"]:
@@ -447,9 +456,14 @@ def main() -> None:
             report.run(reference_data=baseline_df, current_data=current_df)
         report_dict = report_to_dict(report)
         drift_result = get_drift_result(report_dict)
+        report_json_bytes = len(json.dumps(report_dict).encode("utf-8"))
 
         feature_status, drift_summary = summarize_feature_drift(drift_result)
-        prediction = compute_prediction_drift(supabase=supabase, baseline=baseline, current_df=current_df)
+
+        t_psi_start = time.perf_counter()
+        prediction, loaded_model = compute_prediction_drift(supabase=supabase, baseline=baseline, current_df=current_df)
+        t_psi_end = time.perf_counter()
+
         prediction_status = prediction.get("status") if prediction else None
         overall_status = combine_status(feature_status=feature_status, prediction_status=prediction_status)
 
@@ -471,7 +485,7 @@ def main() -> None:
 
         html_report_uri = None
         bucket = storage_bucket()
-        if os.getenv("DRIFTWATCH_UPLOAD_HTML", "true").lower() in {"1", "true", "yes"}:
+        if os.getenv("DRIFTWATCH_UPLOAD_HTML", "false").lower() in {"1", "true", "yes"}:
             html_temp = Path("/tmp") / f"{run_id}.html"
             report.save_html(str(html_temp))
             html_report_uri = supabase.upload_bytes(
@@ -490,7 +504,7 @@ def main() -> None:
                 "current_batch": current_source,
                 "feature_batch_id": feature_batch.get("id") if feature_batch else None,
                 "scenario": feature_batch.get("scenario") if feature_batch else None,
-                "source_mode": feature_batch.get("source_mode") if feature_batch else "legacy",
+                "source_mode": feature_batch.get("source_mode") if feature_batch else "synthetic",
             },
             "drift": drift_summary,
             "prediction_drift": prediction,
@@ -537,6 +551,58 @@ def main() -> None:
             filters={"id": f"eq.{domain_id}"},
             data={"last_worker_heartbeat": now_iso()},
         )
+
+        # Model performance metrics (non-fatal)
+        if loaded_model is not None:
+            compute_performance_metrics(
+                run_id=run_id,
+                model=loaded_model,
+                current_df=current_df,
+                feature_columns=FEATURE_COLUMNS,
+                supabase=supabase,
+            )
+
+        # Retraining trigger policy (non-fatal)
+        try:
+            check_trigger_policy(
+                run_id=run_id,
+                domain_key=args.domain,
+                drift_status=overall_status,
+                prediction_drift_score=prediction.get("psi") if prediction else None,
+                supabase=supabase,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log(f"retraining trigger non-fatal error: {exc}")
+
+        # Alert dispatcher (non-fatal)
+        try:
+            dispatch_alert(
+                run_id=run_id,
+                drift_status=overall_status,
+                prediction_drift_score=prediction.get("psi") if prediction else None,
+                top_features=drift_summary.get("top_features", []),
+                supabase=supabase,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log(f"alert dispatcher non-fatal error: {exc}")
+
+        # System observability metrics (non-fatal)
+        wall_end = time.perf_counter()
+        try:
+            supabase.insert("monitoring_metrics", [{
+                "run_id": run_id,
+                "run_duration_seconds": round(wall_end - wall_start, 3),
+                "batch_size": len(current_df),
+                "features_processed": len(feature_rows),
+                "rows_processed": len(current_df),
+                "baseline_rows": len(baseline_df),
+                "evidently_report_size_bytes": report_json_bytes,
+                "psi_compute_ms": round((t_psi_end - t_psi_start) * 1000),
+                "total_compute_ms": round((wall_end - wall_start) * 1000),
+                "recorded_at": now_iso(),
+            }])
+        except Exception as exc:  # noqa: BLE001
+            log(f"observability metrics write failed (non-fatal): {exc}")
 
         log(f"run {run_id} completed with drift_status={overall_status}")
     except Exception as exc:

--- a/scripts/performance_monitor.py
+++ b/scripts/performance_monitor.py
@@ -1,0 +1,87 @@
+"""Model performance monitoring: computes accuracy, precision, recall, F1, AUC on current batch."""
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+try:
+    from sklearn.metrics import (
+        accuracy_score,
+        precision_score,
+        recall_score,
+        f1_score,
+        roc_auc_score,
+    )
+except ImportError:
+    raise RuntimeError("scikit-learn is required for performance_monitor.py")
+
+from common import log, now_iso
+
+
+def create_ground_truth_labels(df: pd.DataFrame) -> pd.Series:
+    """Generate synthetic ground truth labels using the same rule as training.
+
+    high_spender = daily_spend_30d > median(daily_spend_30d)
+    This is consistent with train_model.py:create_training_target().
+    """
+    if "daily_spend_30d" not in df.columns:
+        raise RuntimeError("Cannot compute ground truth: 'daily_spend_30d' not in columns")
+    threshold = float(df["daily_spend_30d"].median())
+    labels = (df["daily_spend_30d"] > threshold).astype(int)
+    # Ensure at least 2 classes
+    if labels.nunique() < 2:
+        alt = float(df["daily_spend_30d"].quantile(0.6))
+        labels = (df["daily_spend_30d"] > alt).astype(int)
+    return labels
+
+
+def compute_performance_metrics(
+    run_id: str,
+    model,
+    current_df: pd.DataFrame,
+    feature_columns: List[str],
+    supabase,
+) -> Optional[Dict[str, float]]:
+    """Score the current batch, derive ground truth labels, compute and store metrics."""
+    input_cols = [c for c in feature_columns if c in current_df.columns]
+    if not input_cols:
+        log("performance_monitor: no feature columns found, skipping")
+        return None
+
+    try:
+        y_true = create_ground_truth_labels(current_df)
+        probs = model.predict_proba(current_df[input_cols])[:, 1]
+        y_pred = (probs >= 0.5).astype(int)
+
+        metrics: Dict[str, float] = {
+            "accuracy": float(accuracy_score(y_true, y_pred)),
+            "precision": float(precision_score(y_true, y_pred, zero_division=0)),
+            "recall": float(recall_score(y_true, y_pred, zero_division=0)),
+            "f1": float(f1_score(y_true, y_pred, zero_division=0)),
+        }
+        if y_true.nunique() >= 2:
+            metrics["auc"] = float(roc_auc_score(y_true, probs))
+
+        rows: List[Dict[str, Any]] = [
+            {
+                "run_id": run_id,
+                "metric_name": name,
+                "metric_value": round(value, 6),
+                "computed_at": now_iso(),
+            }
+            for name, value in metrics.items()
+        ]
+
+        supabase.insert("model_performance_metrics", rows)
+        log(
+            f"performance: acc={metrics['accuracy']:.4f} "
+            f"prec={metrics['precision']:.4f} "
+            f"rec={metrics['recall']:.4f} "
+            f"f1={metrics['f1']:.4f} "
+            + (f"auc={metrics.get('auc', 0):.4f}" if "auc" in metrics else "auc=n/a")
+        )
+        return metrics
+
+    except Exception as exc:  # noqa: BLE001
+        log(f"performance_monitor: non-fatal error: {exc}")
+        return None

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,10 @@
+# Pinned dependencies for reproducible DriftWatch pipeline builds
+# Generated from known-good environment. Update with pip freeze after testing upgrades.
+evidently==0.6.7
+scikit-learn==1.5.2
+pandas==2.2.3
+numpy==1.26.4
+joblib==1.4.2
+requests==2.32.3
+pytest==8.3.3
+pytest-cov==5.0.0

--- a/scripts/retraining_trigger.py
+++ b/scripts/retraining_trigger.py
@@ -1,0 +1,81 @@
+"""Retraining trigger policy: creates a retraining_events row when drift criteria are met.
+
+Policy: consecutive_red_3
+  - drift_status == "red"
+  - prediction_drift_score > 0.10
+  - last 3 consecutive completed runs for the domain are all "red"
+
+On trigger: writes a retraining_events row with status=pending.
+Admin UI shows pending events and manually approves dispatch.
+"""
+from typing import Any, Dict, Optional
+
+from common import log, now_iso
+
+POLICY_NAME = "consecutive_red_3"
+CONSECUTIVE_RED_THRESHOLD = 3
+MIN_PREDICTION_PSI = 0.10
+
+
+def check_trigger_policy(
+    run_id: str,
+    domain_key: str,
+    drift_status: str,
+    prediction_drift_score: Optional[float],
+    supabase,
+) -> Optional[Dict[str, Any]]:
+    """Evaluate retraining trigger policy and create event if triggered.
+
+    Returns the retraining event row if triggered, else None.
+    """
+    if drift_status != "red":
+        return None
+
+    if prediction_drift_score is None or prediction_drift_score <= MIN_PREDICTION_PSI:
+        return None
+
+    # Fetch last N completed runs for this domain
+    recent_runs = supabase.select(
+        "monitor_runs",
+        select="id,drift_status,prediction_drift_score,status",
+        filters={"domain_key": f"eq.{domain_key}", "status": f"eq.completed"},
+        order="created_at.desc",
+        limit=CONSECUTIVE_RED_THRESHOLD,
+    )
+
+    if len(recent_runs) < CONSECUTIVE_RED_THRESHOLD:
+        log(f"retraining_trigger: only {len(recent_runs)} completed runs, need {CONSECUTIVE_RED_THRESHOLD}")
+        return None
+
+    consecutive_red = all(r.get("drift_status") == "red" for r in recent_runs)
+    if not consecutive_red:
+        log(f"retraining_trigger: not all last {CONSECUTIVE_RED_THRESHOLD} runs are red, policy not triggered")
+        return None
+
+    # Check if there's already a pending event to avoid duplicates
+    existing = supabase.select(
+        "retraining_events",
+        select="id",
+        filters={"status": "eq.pending"},
+        limit=1,
+    )
+    if existing:
+        log("retraining_trigger: pending event already exists, skipping")
+        return None
+
+    event = {
+        "trigger_run_id": run_id,
+        "policy_name": POLICY_NAME,
+        "consecutive_red_count": CONSECUTIVE_RED_THRESHOLD,
+        "prediction_drift_score": round(prediction_drift_score, 6),
+        "status": "pending",
+        "triggered_at": now_iso(),
+        "notes": f"Auto-triggered after {CONSECUTIVE_RED_THRESHOLD} consecutive red runs for domain={domain_key}",
+    }
+
+    inserted = supabase.insert("retraining_events", [event])
+    log(
+        f"retraining_trigger: TRIGGERED policy={POLICY_NAME} "
+        f"psi={prediction_drift_score:.4f} domain={domain_key}"
+    )
+    return inserted[0] if inserted else None

--- a/scripts/sweeper.py
+++ b/scripts/sweeper.py
@@ -1,20 +1,37 @@
 import argparse
 import datetime as dt
+from urllib.parse import urlparse
 
 from common import get_supabase, log, now_iso
 
 
+def storage_path_from_uri(uri: str, bucket: str) -> str | None:
+    if not uri:
+        return None
+    parsed = urlparse(uri)
+    marker = f"/storage/v1/object/public/{bucket}/"
+    if marker in parsed.path:
+        return parsed.path.split(marker, 1)[1]
+    return None
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("--timeout-minutes", type=int, default=10)
+    # Default threshold matches sweep interval (sweeper runs every 30 min)
+    parser.add_argument("--timeout-minutes", type=int, default=25)
+    parser.add_argument("--purge-days", type=int, default=30,
+                        help="Delete HTML reports older than this many days")
     args = parser.parse_args()
 
     supabase = get_supabase()
+    bucket = "driftwatch-artifacts"
     cutoff = (dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=args.timeout_minutes)).isoformat()
+    purge_cutoff = (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=args.purge_days)).isoformat()
 
+    # 1. Mark stale processing runs as failed
     stale = supabase.select(
         "monitor_runs",
-        select="id,status,started_at",
+        select="id,status,started_at,html_report_uri",
         filters={"status": "eq.processing", "started_at": f"lt.{cutoff}"},
     )
 
@@ -28,8 +45,41 @@ def main() -> None:
                 "finished_at": now_iso(),
             },
         )
+        # Clean up HTML report if present
+        uri = run.get("html_report_uri")
+        if uri:
+            path = storage_path_from_uri(uri, bucket)
+            if path:
+                supabase.delete_storage_object(bucket, path)
+                log(f"deleted stale report {path}")
 
     log(f"sweeper marked {len(stale)} stale runs as failed")
+
+    # 2. Purge old HTML reports from completed/failed runs
+    old_runs = supabase.select(
+        "monitor_runs",
+        select="id,html_report_uri",
+        filters={
+            "html_report_uri": "not.is.null",
+            "finished_at": f"lt.{purge_cutoff}",
+        },
+    )
+
+    purged = 0
+    for run in old_runs:
+        uri = run.get("html_report_uri")
+        if not uri:
+            continue
+        path = storage_path_from_uri(uri, bucket)
+        if path and supabase.delete_storage_object(bucket, path):
+            supabase.update(
+                "monitor_runs",
+                filters={"id": f"eq.{run['id']}"},
+                data={"html_report_uri": None},
+            )
+            purged += 1
+
+    log(f"sweeper purged {purged} HTML reports older than {args.purge_days} days")
 
 
 if __name__ == "__main__":

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -79,6 +79,7 @@ def run_training(
     rows: int,
     seed: Optional[int],
     scenario: str,
+    model_role: str = "champion",
 ) -> Dict[str, Any]:
     supabase = get_supabase()
     domains = supabase.select("domains", select="id,key", filters={"key": f"eq.{domain}"}, limit=1)
@@ -112,6 +113,10 @@ def run_training(
         "application/octet-stream",
     )
 
+    # Capture git commit hash for lineage (GITHUB_SHA is set in GitHub Actions)
+    import os as _os
+    training_commit_hash = _os.getenv("GITHUB_SHA", "local")
+
     upserted = supabase.upsert(
         "baselines",
         [
@@ -125,6 +130,11 @@ def run_training(
                 "model_uri": model_uri,
                 "baseline_predictions_json": prediction_hist,
                 "reason": f"synthetic baseline refresh scenario={scenario}",
+                "model_role": model_role,
+                "training_commit_hash": training_commit_hash,
+                "metrics_json": metrics,
+                "is_active": True,
+                "promoted_at": now_iso(),
             }
         ],
         on_conflict="domain_id,baseline_version",
@@ -158,6 +168,7 @@ def main() -> None:
     parser.add_argument("--rows", type=int, default=200)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--scenario", default="stable_salary")
+    parser.add_argument("--model-role", default="champion", choices=["champion", "challenger"])
     args = parser.parse_args()
 
     run_training(
@@ -166,6 +177,7 @@ def main() -> None:
         rows=args.rows,
         seed=args.seed,
         scenario=args.scenario,
+        model_role=args.model_role,
     )
 
 

--- a/supabase/migration_v3.sql
+++ b/supabase/migration_v3.sql
@@ -1,0 +1,141 @@
+-- DriftWatch Migration v3
+-- Adds: model performance metrics, retraining events, data quality metrics,
+--       alert logs, monitoring metrics, baseline lineage columns,
+--       champion/challenger support, triggered_by on monitor_runs
+
+-- ─────────────────────────────────────────────
+-- 1. model_performance_metrics
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS model_performance_metrics (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id uuid REFERENCES monitor_runs(id) ON DELETE CASCADE,
+  metric_name text NOT NULL,   -- accuracy | precision | recall | f1 | auc
+  metric_value float NOT NULL,
+  computed_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE model_performance_metrics ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "public read model_performance_metrics"
+  ON model_performance_metrics FOR SELECT USING (true);
+
+CREATE INDEX IF NOT EXISTS idx_model_perf_run_id
+  ON model_performance_metrics (run_id);
+
+-- ─────────────────────────────────────────────
+-- 2. retraining_events
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS retraining_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  triggered_at timestamptz DEFAULT now(),
+  trigger_run_id uuid REFERENCES monitor_runs(id) ON DELETE SET NULL,
+  policy_name text NOT NULL,          -- e.g. "consecutive_red_3"
+  consecutive_red_count int,
+  prediction_drift_score float,
+  status text DEFAULT 'pending',      -- pending | dispatched | skipped | cancelled
+  baseline_version text,
+  notes text
+);
+
+ALTER TABLE retraining_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "public read retraining_events"
+  ON retraining_events FOR SELECT USING (true);
+
+CREATE INDEX IF NOT EXISTS idx_retraining_events_status
+  ON retraining_events (status);
+
+-- ─────────────────────────────────────────────
+-- 3. data_quality_metrics
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS data_quality_metrics (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id uuid REFERENCES monitor_runs(id) ON DELETE CASCADE,
+  feature_name text NOT NULL,
+  missing_rate float,
+  outlier_rate float,
+  null_ratio float,
+  schema_change boolean DEFAULT false,
+  computed_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE data_quality_metrics ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "public read data_quality_metrics"
+  ON data_quality_metrics FOR SELECT USING (true);
+
+CREATE INDEX IF NOT EXISTS idx_data_quality_run_id
+  ON data_quality_metrics (run_id);
+
+-- ─────────────────────────────────────────────
+-- 4. alert_logs
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS alert_logs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id uuid REFERENCES monitor_runs(id) ON DELETE SET NULL,
+  channel text NOT NULL,       -- github_issue | slack | webhook
+  status text NOT NULL,        -- sent | failed | skipped
+  response_code int,
+  sent_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE alert_logs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "public read alert_logs"
+  ON alert_logs FOR SELECT USING (true);
+
+CREATE INDEX IF NOT EXISTS idx_alert_logs_run_id
+  ON alert_logs (run_id);
+
+-- ─────────────────────────────────────────────
+-- 5. monitoring_metrics (system observability)
+-- ─────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS monitoring_metrics (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id uuid REFERENCES monitor_runs(id) ON DELETE CASCADE,
+  run_duration_seconds float,
+  batch_size int,
+  features_processed int,
+  rows_processed int,
+  baseline_rows int,
+  evidently_report_size_bytes int,
+  psi_compute_ms int,
+  total_compute_ms int,
+  recorded_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE monitoring_metrics ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "public read monitoring_metrics"
+  ON monitoring_metrics FOR SELECT USING (true);
+
+CREATE INDEX IF NOT EXISTS idx_monitoring_metrics_run_id
+  ON monitoring_metrics (run_id);
+
+-- ─────────────────────────────────────────────
+-- 6. Extend monitor_runs: triggered_by + comparison_run_id
+-- ─────────────────────────────────────────────
+ALTER TABLE monitor_runs
+  ADD COLUMN IF NOT EXISTS triggered_by text DEFAULT 'cron';
+
+ALTER TABLE monitor_runs
+  ADD COLUMN IF NOT EXISTS comparison_run_id uuid REFERENCES monitor_runs(id);
+
+-- ─────────────────────────────────────────────
+-- 7. Extend baselines: lineage + champion/challenger
+-- ─────────────────────────────────────────────
+ALTER TABLE baselines
+  ADD COLUMN IF NOT EXISTS model_role text DEFAULT 'champion';
+
+ALTER TABLE baselines
+  ADD COLUMN IF NOT EXISTS training_commit_hash text;
+
+ALTER TABLE baselines
+  ADD COLUMN IF NOT EXISTS training_dataset_id text;
+
+ALTER TABLE baselines
+  ADD COLUMN IF NOT EXISTS metrics_json jsonb;
+
+ALTER TABLE baselines
+  ADD COLUMN IF NOT EXISTS is_active boolean DEFAULT false;
+
+ALTER TABLE baselines
+  ADD COLUMN IF NOT EXISTS promoted_at timestamptz;
+
+ALTER TABLE baselines
+  ADD COLUMN IF NOT EXISTS promoted_by text;

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,100 @@
+"""Tests for common.py: SupabaseClient, retry logic, and helpers."""
+import json
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+import requests
+
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from common import _retry_request, now_iso, SupabaseClient
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, body=None):
+        self.status_code = status_code
+        self._body = body or {}
+        self.ok = status_code < 400
+        self.content = json.dumps(self._body).encode()
+
+    def json(self):
+        return self._body
+
+    def raise_for_status(self):
+        if not self.ok:
+            raise requests.HTTPError(f"{self.status_code}", response=self)
+
+
+# ---------- _retry_request ----------
+
+def test_retry_succeeds_on_first_attempt():
+    mock_fn = MagicMock(return_value=FakeResponse(200, {"ok": True}))
+    result = _retry_request(mock_fn, "http://example.com", retries=3)
+    assert mock_fn.call_count == 1
+    assert result.json() == {"ok": True}
+
+
+def test_retry_retries_on_network_error_then_succeeds():
+    mock_fn = MagicMock(side_effect=[
+        requests.ConnectionError("timeout"),
+        FakeResponse(200, {"ok": True}),
+    ])
+    with patch("common.time.sleep"):
+        result = _retry_request(mock_fn, "http://example.com", retries=3)
+    assert mock_fn.call_count == 2
+    assert result.json() == {"ok": True}
+
+
+def test_retry_exhausts_retries_and_raises():
+    mock_fn = MagicMock(side_effect=requests.ConnectionError("always fails"))
+    with patch("common.time.sleep"):
+        with pytest.raises(requests.ConnectionError):
+            _retry_request(mock_fn, "http://example.com", retries=3)
+    assert mock_fn.call_count == 3
+
+
+# ---------- now_iso ----------
+
+def test_now_iso_format():
+    ts = now_iso()
+    import re
+    # e.g. 2026-03-13T10:00:00Z
+    assert re.match(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", ts), f"Unexpected format: {ts}"
+
+
+# ---------- SupabaseClient.select ----------
+
+def test_supabase_select_constructs_correct_url():
+    client = SupabaseClient(url="https://example.supabase.co", service_key="test-key")
+    fake_resp = FakeResponse(200, [{"id": "1"}])
+
+    with patch("common._retry_request", return_value=fake_resp) as mock_retry:
+        result = client.select("domains", select="id,key", filters={"key": "eq.nordea"}, limit=1)
+
+    assert result == [{"id": "1"}]
+    args, kwargs = mock_retry.call_args
+    assert "domains" in args[1]
+    assert kwargs["params"]["select"] == "id,key"
+    assert kwargs["params"]["key"] == "eq.nordea"
+    assert kwargs["params"]["limit"] == "1"
+
+
+def test_supabase_delete_storage_object_returns_true_on_success():
+    client = SupabaseClient(url="https://example.supabase.co", service_key="test-key")
+    fake_resp = FakeResponse(200, {})
+    fake_resp.raise_for_status = lambda: None
+
+    with patch("requests.delete", return_value=fake_resp):
+        result = client.delete_storage_object("my-bucket", "path/to/object.html")
+
+    assert result is True
+
+
+def test_supabase_delete_storage_object_returns_false_on_error():
+    client = SupabaseClient(url="https://example.supabase.co", service_key="test-key")
+
+    with patch("requests.delete", side_effect=requests.ConnectionError("network error")):
+        result = client.delete_storage_object("my-bucket", "path/to/object.html")
+
+    assert result is False

--- a/tests/test_sweeper.py
+++ b/tests/test_sweeper.py
@@ -1,0 +1,28 @@
+"""Tests for sweeper.py: timeout detection and storage path extraction."""
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from sweeper import storage_path_from_uri
+
+
+def test_storage_path_extracts_correctly():
+    uri = "https://abc.supabase.co/storage/v1/object/public/driftwatch-artifacts/reports/run/report.html"
+    path = storage_path_from_uri(uri, "driftwatch-artifacts")
+    assert path == "reports/run/report.html"
+
+
+def test_storage_path_returns_none_for_wrong_bucket():
+    uri = "https://abc.supabase.co/storage/v1/object/public/other-bucket/reports/report.html"
+    path = storage_path_from_uri(uri, "driftwatch-artifacts")
+    assert path is None
+
+
+def test_storage_path_returns_none_for_empty_uri():
+    assert storage_path_from_uri("", "driftwatch-artifacts") is None
+    assert storage_path_from_uri(None, "driftwatch-artifacts") is None
+
+
+def test_storage_path_nested_path():
+    uri = "https://x.supabase.co/storage/v1/object/public/driftwatch-artifacts/baselines/nordea/v1.csv"
+    path = storage_path_from_uri(uri, "driftwatch-artifacts")
+    assert path == "baselines/nordea/v1.csv"


### PR DESCRIPTION
Testing observability

- ISR caching (revalidate 60s) on all list pages; selective column fetch drops ~80% payload
- Ticket resolve/acknowledge API route + TicketActions UI component
- URL-based filter state in runs table (shareable, survives refresh)
- RunStatusPoller auto-refreshes processing runs every 5s
- Dark mode toggle (ThemeToggle) with localStorage persistence and FOUC prevention
- FeatureDriftChart (Recharts BarChart) on run detail page
- In-memory rate limiter on admin login (5 attempts / 15 min)
- Zod-style input validation on all admin dispatch routes via lib/admin-validation.ts
- Admin panel: Pending Retraining Events card + System Health stats card
- alert_dispatcher.py: GitHub Issues only (no Slack), triggered on red drift
- Storage sweeper extended: delete orphaned HTML reports + 30-day purge
- keepalive.py: bucket size monitoring with warning at 400MB
- monitor_run.py: data quality checks, performance metrics, retrain trigger, observability
- New Python scripts: data_quality_checks, performance_monitor, retraining_trigger
- scripts/requirements.txt with pinned versions; CI updated to use it
- New test files: test_common.py (7 tests), test_sweeper.py (4 tests)
- pytest.ini: coverage reporting with --cov-fail-under=50
- supabase/migration_v3.sql: 5 new tables + ALTER TABLE additions
- README: ASCII architecture diagram + storage lifecycle docs
- Accessibility: role="status", aria-label on badges; aria-label on pagination buttons